### PR TITLE
fix: reduced size for switch widget in args table

### DIFF
--- a/.storybook/storybook-styles.scss
+++ b/.storybook/storybook-styles.scss
@@ -193,6 +193,12 @@ div:has(.docblock-argstable) {
 
 table.docblock-argstable {
   min-width: 960px;
+
+  label:has([role='switch'][type='checkbox']) {
+    span {
+      padding: 2px 10px;
+    }
+  }
 }
 
 .flex {


### PR DESCRIPTION
Ridotta la dimensione dei widget di switch nella tabella degli attributi del componente
