### PR TITLE
Fixed slash-div sass deprecation warning

### DIFF
--- a/packages/dev-kit-italia/styles/utilities/fuoc.scss
+++ b/packages/dev-kit-italia/styles/utilities/fuoc.scss
@@ -1,3 +1,5 @@
+@use 'sass:list';
+
 :root {
   --it-fouc-bg: #ddd;
   --it-host-display: inline-block;
@@ -128,7 +130,9 @@ $it-components: (
   'it-video': (
     height: auto,
     width: 100%,
-    aspect-ratio: 16 / 9,
+    // Check the Heads up! section in the documentation
+    // https://sass-lang.com/documentation/modules/list/#slash
+    aspect-ratio: list.slash(16, 9),
   ),
 );
 

--- a/packages/video/src/it-video.scss
+++ b/packages/video/src/it-video.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @import 'bootstrap-italia/src/scss/base/functions';
 @import 'bootstrap-italia/src/scss/base/variables';
 @import 'bootstrap-italia/src/scss/base/mixins';
@@ -9,7 +10,9 @@
 @import 'bootstrap-italia/src/scss/components/accept-overlay';
 
 .acceptoverlayable {
-  aspect-ratio: 16 / 9;
+  // Check the Heads up! section in the documentation
+  // https://sass-lang.com/documentation/modules/list/#slash
+  aspect-ratio: list.slash(16, 9);
 }
 
 .acceptoverlay {
@@ -91,7 +94,9 @@ video:not([width]) {
 
   &.vjs-youtube {
     .vjs-tech {
-      aspect-ratio: 16/9;
+      // Check the Heads up! section in the documentation
+      // https://sass-lang.com/documentation/modules/list/#slash
+      aspect-ratio: list.slash(16, 9);
     }
   }
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Changes proposed in this Pull Request:

Ho rimosso un warning di sass e fatto una modifica la cui sintassi non è bellissima (nella versione di sass odierna) ma alla fine dà il risultato giusto.