### PR TITLE
test: verify compatibility with new BSI 3.x Sass migration branch (PR #1678)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ catalogs:
       specifier: ^0.9.0
       version: 0.9.0
     bootstrap-italia:
-      specifier: 3.0.0-alpha.2
+      specifier: github:italia/bootstrap-italia#sass-use-migration-3x
       version: 3.0.0-alpha.2
     design-tokens-italia:
       specifier: ^1.3.3
@@ -74,7 +74,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       design-tokens-italia:
         specifier: 'catalog:'
         version: 1.3.3
@@ -167,7 +167,7 @@ importers:
         version: link:../icon
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -228,7 +228,7 @@ importers:
         version: link:../i18n
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -289,7 +289,7 @@ importers:
         version: link:../i18n
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -347,7 +347,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -402,7 +402,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -457,7 +457,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -512,7 +512,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -573,7 +573,7 @@ importers:
         version: link:../i18n
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -628,7 +628,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -692,7 +692,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -838,7 +838,7 @@ importers:
         version: 12.3.0(rollup@4.59.0)(tslib@2.8.1)(typescript@5.9.3)
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       design-tokens-italia:
         specifier: 'catalog:'
         version: 1.3.3
@@ -868,7 +868,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -975,7 +975,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1073,7 +1073,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1137,7 +1137,7 @@ importers:
         version: link:../i18n
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1195,7 +1195,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1256,7 +1256,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1317,7 +1317,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: ^3.2.1
         version: 3.3.2
@@ -1378,7 +1378,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1439,7 +1439,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1500,7 +1500,7 @@ importers:
         version: link:../radio
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1552,7 +1552,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1610,7 +1610,7 @@ importers:
         version: link:../i18n
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1668,7 +1668,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1720,7 +1720,7 @@ importers:
         version: link:../globals
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -1859,7 +1859,7 @@ importers:
         version: link:../i18n
       bootstrap-italia:
         specifier: 'catalog:'
-        version: 3.0.0-alpha.2
+        version: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906
       lit:
         specifier: 'catalog:'
         version: 3.3.2
@@ -4039,8 +4039,9 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  bootstrap-italia@3.0.0-alpha.2:
-    resolution: {integrity: sha512-rPxvQE2OG6zkR0rdRyVSEMBK6cMGhO2M79TfnMFm+u0FeJR3+kHZ9dr0nQJDXQQkTf5ff6+L4HCQLYKKaQ+9LA==}
+  bootstrap-italia@https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906:
+    resolution: {tarball: https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906}
+    version: 3.0.0-alpha.2
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -9407,7 +9408,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  bootstrap-italia@3.0.0-alpha.2:
+  bootstrap-italia@https://codeload.github.com/italia/bootstrap-italia/tar.gz/21cb66d3cb432908bcd11dd6a2cb5fdfc20d2906:
     dependencies:
       '@popperjs/core': 2.11.8
       '@splidejs/splide': 4.1.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ catalog:
   '@types/mocha': '^10.0.10'
   '@web/test-runner': '^0.18.2'
   '@web/test-runner-commands': '^0.9.0'
-  bootstrap-italia: '3.0.0-alpha.2'
+  bootstrap-italia: 'github:italia/bootstrap-italia#sass-use-migration-3x' # testing new sass-use-migration-3x branch of BSI v3.x
   design-tokens-italia: '^1.3.3'
   lit: '^3.3.0'
   sass: '^1.89.0'


### PR DESCRIPTION
## Purpose

Test compatibility of Dev Kit Italia with Bootstrap Italia 3.x branch featuring:
- Sass `@use`/`@forward` migration (replacing deprecated `@import`)
- Full design tokens integration
- Dart Sass 3.0 preparation

This PR uses the `sass-use-migration-3x` branch to identify breaking changes before merging [italia/bootstrap-italia#1678](https://github.com/italia/bootstrap-italia/pull/1678).

---

## ⚠️ Important Notes

**New SCSS files in BSI 3.x branch:**
- `base/_config.scss` - Primitive variables (separated from `_variables.scss`)
- `base/mixins/_progress.scss` - Shared progress component mixin
- Updated file structure and import patterns

If you encounter issues with these files or need clarification on the new architecture, please:
- Check the work in BSI `sass-use-migration-3x` branch (details in [PR #1678 README](https://github.com/italia/bootstrap-italia/pull/1678)) 
- Ask @Fupete for clarifications

---

## Testing Scope

**Bootstrap Italia dependency:**
```yaml
bootstrap-italia: 'github:italia/bootstrap-italia#sass-use-migration-3x'
```

**Expected potential issues:**
- [ ] Build failures (Sass compilation errors)
- [ ] Missing CSS custom properties (design tokens mapping)
- [ ] Component rendering issues
- [ ] Customization patterns broken (Sass variable overrides)
- [ ] Build performance regression

---

## How to Test
```bash
npm install
npm run build
npm start
```

**Manual verification:**
- [ ] All pages render correctly
- [ ] Components work as expected
- [ ] No console errors
- [ ] Storybook builds (if applicable)
- [ ] Design tokens applied correctly

---

## Expected Outcome

- ✅ **If passing:** BSI 3.x migration is backward compatible
- ⚠️ **If failing:** Document breaking changes and required Dev Kit updates

---

## Related

- Bootstrap Italia PR: [#1678 - Sass @use/@forward migration](https://github.com/italia/bootstrap-italia/pull/1678)
- BSI branch: `sass-use-migration-3x` → target `3.x`
- Complementary: [#1689 - Rollup Sass plugin update](https://github.com/italia/bootstrap-italia/pull/1689) [✅ **already merged]**

---

## PR Checklist

- [x] Branch uses BSI `sass-use-migration-3x` dependency
- [ ] Build passes without errors
- [ ] All components render correctly
- [ ] No regression in functionality
- [ ] Documentation updated (if changes needed)

---

## Notes

**DO NOT MERGE** until [italia/bootstrap-italia#1678](https://github.com/italia/bootstrap-italia/pull/1678) is merged to BSI `3.x` branch.

This is a **test-only PR** to validate compatibility and identify necessary Dev Kit updates.

---

/cc @pnicolli @giuliaghisini @astagi @zetareticoli 