### PR TITLE
fix: position and z-index for containers in it-section

### DIFF
--- a/.changeset/twenty-mangos-enter.md
+++ b/.changeset/twenty-mangos-enter.md
@@ -1,0 +1,5 @@
+---
+'@italia/section': patch
+---
+
+fix: position and z-index for containers in it-section

--- a/packages/section/styles/globals.scss
+++ b/packages/section/styles/globals.scss
@@ -28,6 +28,14 @@
 
 it-section .container {
   @extend .container;
+}
+
+it-section .container-xxl,
+it-section .container-xl,
+it-section .container-lg,
+it-section .container-md,
+it-section .container-sm,
+it-section .container {
   position: relative;
   z-index: 2;
 }


### PR DESCRIPTION
dento al componente it-section, nel lightdom si possono usare altre classi oltre a `container` per fare i container (come ad esempio `.container-xxl`). 

Quindi le regole già previste per la classe `container` (z-index e position) sono state estese anche alle altre tipologie di containers