### PR TITLE
fix(angular-app): import CommonModule in ThumbnnavComponent 

### DIFF
--- a/examples/angular-app/src/app/pages/thumbnav.component.ts
+++ b/examples/angular-app/src/app/pages/thumbnav.component.ts
@@ -1,8 +1,10 @@
 import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-thumbnav',
   templateUrl: './thumbnav.component.html',
+  imports: [CommonModule],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   standalone: true,
 })


### PR DESCRIPTION
Without CommonModule in the component imports, Angular couldn't resolve the NgFor directive on it-thumbnav-item, causing NG0303 errors and rendering an empty placeholder comment instead of the thumbnail items.

Fixes #388
