### PR TITLE
Added `heading-size` property to `it-card`

### DIFF
--- a/.changeset/green-aliens-notice.md
+++ b/.changeset/green-aliens-notice.md
@@ -1,0 +1,5 @@
+---
+'@italia/card': minor
+---
+
+Added `heading-size` property to the card component

--- a/packages/card/src/it-card.ts
+++ b/packages/card/src/it-card.ts
@@ -8,11 +8,13 @@ import {
   CARD_SHADOWS,
   CARD_VARIANTS,
   CARD_HEADING_LEVELS,
+  CARD_HEADING_SIZES,
   CardShadow,
   type CardBorderColor,
   type CardImageRatio,
   type CardVariant,
   type CardHeadingLevel,
+  type CardHeadingSize,
 } from './types.js';
 import styles from './card.scss';
 
@@ -40,6 +42,9 @@ export class ItCard extends BaseComponent {
 
   @property({ type: String, attribute: 'heading-level' })
   headingLevel: CardHeadingLevel = 'h3';
+
+  @property({ type: String, attribute: 'heading-size' })
+  headingSize?: CardHeadingSize;
 
   @property({ type: String, attribute: 'it-class' })
   itClass: string | undefined;
@@ -106,6 +111,11 @@ export class ItCard extends BaseComponent {
     if (this.headingLevel && !CARD_HEADING_LEVELS.includes(this.headingLevel)) {
       this.logger.warn(
         `Invalid heading-level value, falling back to default. Expected one of: ${CARD_HEADING_LEVELS.join(', ')}`,
+      );
+    }
+    if (this.headingSize && !CARD_HEADING_SIZES.includes(this.headingSize)) {
+      this.logger.warn(
+        `Invalid heading-size value, falling back to default. Expected one of: ${CARD_HEADING_SIZES.join(', ')}`,
       );
     }
   }
@@ -183,18 +193,22 @@ export class ItCard extends BaseComponent {
       'it-card-profile-name': this.variant === 'profile' || this.variant === 'location',
       'it-card-title-icon': hasTitleIcon,
       h4:
-        this.variant === 'inline-mini' ||
-        this.variant === 'inline-mini-reverse' ||
-        this.variant === 'profile' ||
-        this.variant === 'location',
+        this.headingSize === 'sm' ||
+        (this.headingSize === undefined &&
+          (this.variant === 'inline-mini' ||
+            this.variant === 'inline-mini-reverse' ||
+            this.variant === 'profile' ||
+            this.variant === 'location')),
       h3:
-        this.headingLevel !== 'h3' &&
-        !(
-          this.variant === 'inline-mini' ||
-          this.variant === 'inline-mini-reverse' ||
-          this.variant === 'profile' ||
-          this.variant === 'location'
-        ),
+        this.headingSize === 'md' ||
+        (this.headingSize === undefined &&
+          this.headingLevel !== 'h3' &&
+          !(
+            this.variant === 'inline-mini' ||
+            this.variant === 'inline-mini-reverse' ||
+            this.variant === 'profile' ||
+            this.variant === 'location'
+          )),
     });
 
     const headingTag = unsafeStatic(this.getHeadingLevel());

--- a/packages/card/src/types.ts
+++ b/packages/card/src/types.ts
@@ -25,3 +25,6 @@ export type CardShadow = (typeof CARD_SHADOWS)[number];
 
 export const CARD_HEADING_LEVELS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
 export type CardHeadingLevel = (typeof CARD_HEADING_LEVELS)[number];
+
+export const CARD_HEADING_SIZES = ['sm', 'md'] as const;
+export type CardHeadingSize = (typeof CARD_HEADING_SIZES)[number];

--- a/packages/card/stories/it-card.stories.ts
+++ b/packages/card/stories/it-card.stories.ts
@@ -4,10 +4,14 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import {
   CARD_BORDER_COLORS,
   CARD_HEADING_LEVELS,
+  CARD_HEADING_SIZES,
+  CARD_IMAGE_RATIOS,
   CARD_VARIANTS,
   CARD_SHADOWS,
   type CardHeadingLevel,
+  type CardHeadingSize,
   type CardBorderColor,
+  type CardImageRatio,
   type CardVariant,
   type CardShadow,
 } from '../src/types.js';
@@ -15,8 +19,10 @@ import {
 interface CardProps {
   fullHeight?: boolean;
   variant: CardVariant;
+  ratio?: CardImageRatio;
   borderTop?: CardBorderColor;
   headingLevel?: CardHeadingLevel;
+  headingSize?: CardHeadingSize;
   shadow?: CardShadow;
   border?: '0';
   'actions-aria-label'?: string;
@@ -49,6 +55,12 @@ const meta = {
       description: 'Variante di layout della card',
       table: { defaultValue: { summary: 'default' } },
     },
+    ratio: {
+      control: 'select',
+      type: 'string',
+      options: [undefined, ...CARD_IMAGE_RATIOS],
+      description: "Rapporto d'aspetto dell'immagine della card.",
+    },
     borderTop: {
       name: 'border-top',
       control: 'select',
@@ -63,6 +75,14 @@ const meta = {
       options: CARD_HEADING_LEVELS,
       description:
         'Livello di heading da usare per il titolo della card. Se non specificato, viene usato h3. Vedi la sezione "Accessibilità" della documentazione per maggiori dettagli.',
+    },
+    headingSize: {
+      name: 'heading-size',
+      control: 'select',
+      type: 'string',
+      options: [undefined, ...CARD_HEADING_SIZES],
+      description:
+        'Dimensione visiva del titolo della card. Se "sm" applica la classe h4, se "md" applica la classe h3. Se non specificato, la dimensione è determinata dalla variante.',
     },
     shadow: {
       control: 'select',
@@ -87,23 +107,6 @@ const meta = {
       description:
         "Aggiunge classi custom alla card generata. Utile per impostare padding custom all'interno della Card.",
     },
-    // scrollLimit: {
-    //   name: 'scroll-limit',
-    //   control: 'number',
-    //   type: 'number',
-    //   description: "Posizione Y espressa in pixel alla quale far comparire l'elemento",
-    //   table: { defaultValue: { summary: '100' } },
-    // },
-    // borderColor: {
-    //   name: 'border-color',
-    //   control: 'text',
-    //   type: 'string',
-    //   defaultValue: 'white',
-    //   description: 'Colore del bordo',
-    //   table: {
-    //     defaultValue: { summary: 'Default: "white". Se è attivo l\'attributo "inverse", il default è "primary".' },
-    //   },
-    // },
   },
 } satisfies Meta<CardProps>;
 
@@ -142,6 +145,8 @@ export const EsempioInterattivo: Story = {
       ?full-height=${args.fullHeight}
       border-top=${ifDefined(args.borderTop)}
       heading-level=${ifDefined(args.headingLevel)}
+      heading-size=${ifDefined(args.headingSize)}
+      ratio=${ifDefined(args.ratio)}
       shadow=${ifDefined(args.shadow)}
       border=${ifDefined(args.border)}
       it-class=${ifDefined(args['it-class'])}

--- a/packages/card/test/it-card.test.ts
+++ b/packages/card/test/it-card.test.ts
@@ -221,6 +221,118 @@ describe('<it-card>', () => {
     });
   });
 
+  describe('property: headingSize', () => {
+    it('applies h4 CSS class to the title when heading-size is "sm"', async () => {
+      const el = await fixture<ItCard>(html`
+        <it-card heading-size="sm">
+          <span slot="title">Card Title</span>
+        </it-card>
+      `);
+
+      await elementUpdated(el);
+
+      const heading = el.shadowRoot?.querySelector('h3');
+      expect(heading).to.exist;
+      expect(heading?.classList.contains('h4')).to.be.true;
+      expect(heading?.classList.contains('h3')).to.be.false;
+    });
+
+    it('applies h3 CSS class to the title when heading-size is "md"', async () => {
+      const el = await fixture<ItCard>(html`
+        <it-card heading-size="md">
+          <span slot="title">Card Title</span>
+        </it-card>
+      `);
+
+      await elementUpdated(el);
+
+      const heading = el.shadowRoot?.querySelector('h3');
+      expect(heading).to.exist;
+      expect(heading?.classList.contains('h3')).to.be.true;
+      expect(heading?.classList.contains('h4')).to.be.false;
+    });
+
+    it('does not apply h4 or h3 CSS class to the title when heading-size is not set (default variant)', async () => {
+      const el = await fixture<ItCard>(html`
+        <it-card>
+          <span slot="title">Card Title</span>
+        </it-card>
+      `);
+
+      await elementUpdated(el);
+
+      const heading = el.shadowRoot?.querySelector('h3');
+      expect(heading).to.exist;
+      expect(heading?.classList.contains('h4')).to.be.false;
+      expect(heading?.classList.contains('h3')).to.be.false;
+    });
+
+    it('applies h4 CSS class when heading-size is "sm" on variant inline-mini (same result as default variant behavior)', async () => {
+      const el = await fixture<ItCard>(html`
+        <it-card variant="inline-mini" heading-size="sm">
+          <span slot="title">Card Title</span>
+        </it-card>
+      `);
+
+      await elementUpdated(el);
+
+      const heading = el.shadowRoot?.querySelector('h3');
+      expect(heading).to.exist;
+      expect(heading?.classList.contains('h4')).to.be.true;
+    });
+
+    it('overrides inline-mini variant h4 CSS class to h3 when heading-size is "md"', async () => {
+      const el = await fixture<ItCard>(html`
+        <it-card variant="inline-mini" heading-size="md">
+          <span slot="title">Card Title</span>
+        </it-card>
+      `);
+
+      await elementUpdated(el);
+
+      const heading = el.shadowRoot?.querySelector('h3');
+      expect(heading).to.exist;
+      expect(heading?.classList.contains('h3')).to.be.true;
+      expect(heading?.classList.contains('h4')).to.be.false;
+    });
+
+    it('applies h4 CSS class when heading-size is "sm" on default variant (overrides default absence of size class)', async () => {
+      const el = await fixture<ItCard>(html`
+        <it-card variant="default" heading-size="sm">
+          <span slot="title">Card Title</span>
+        </it-card>
+      `);
+
+      await elementUpdated(el);
+
+      const heading = el.shadowRoot?.querySelector('h3');
+      expect(heading).to.exist;
+      expect(heading?.classList.contains('h4')).to.be.true;
+      expect(heading?.classList.contains('h3')).to.be.false;
+    });
+
+    it('updates title CSS class when headingSize property changes dynamically', async () => {
+      const el = await fixture<ItCard>(html`
+        <it-card heading-size="sm">
+          <span slot="title">Card Title</span>
+        </it-card>
+      `);
+
+      await elementUpdated(el);
+
+      let heading = el.shadowRoot?.querySelector('h3');
+      expect(heading?.classList.contains('h4')).to.be.true;
+      expect(heading?.classList.contains('h3')).to.be.false;
+
+      el.headingSize = 'md';
+      await elementUpdated(el);
+
+      heading = el.shadowRoot?.querySelector('h3');
+      expect(heading?.classList.contains('h3')).to.be.true;
+      expect(heading?.classList.contains('h4')).to.be.false;
+    });
+  });
+
   describe('variant: default', () => {
     it('renders default card without variant-specific classes', async () => {
       const el = await fixture<ItCard>(html`


### PR DESCRIPTION
#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Aggiunge la property `heading-size` al componente `it-card`. Attualmente la dimensione del titolo della card dipende dalla scelta di variante che viene effettuata, con questo parametro nuovo è possibile forzare la dimensione del titolo manualmente, utile per i casi in cui si affiancano nella stessa griglia delle card di varianti diverse.