### PR TITLE
fix: upload voiceover double focus

### DIFF
--- a/.changeset/thirty-dots-grow.md
+++ b/.changeset/thirty-dots-grow.md
@@ -1,0 +1,5 @@
+---
+'@italia/upload': minor
+---
+
+Rework markup and styles following https://scottaohara.github.io/a11y_styled_form_controls/src/file-upload/ instead of copying BSI approach

--- a/packages/upload/src/it-upload-avatar.ts
+++ b/packages/upload/src/it-upload-avatar.ts
@@ -146,7 +146,7 @@ export class ItUploadAvatar extends FormControl {
             ?required="${this.required && !hasValue}"
             aria-label="${fileInputLabel}"
             aria-required="${this.required ? 'true' : nothing}"
-            aria-invalid="${isInvalid ? 'true' : 'false'}"
+            aria-invalid="${isInvalid ? 'true' : nothing}"
             aria-describedby="${ifDefined(isInvalid ? feedbackId : undefined)}"
             @change="${this._handleFileChange}"
           />

--- a/packages/upload/src/it-upload-drag-drop.ts
+++ b/packages/upload/src/it-upload-drag-drop.ts
@@ -292,7 +292,7 @@ export class ItUploadDragDrop extends FormControl {
             ?required="${this.required && !this._currentFile}"
             aria-label="${fileInputLabel}"
             aria-required="${this.required ? 'true' : nothing}"
-            aria-invalid="${isInvalid ? 'true' : 'false'}"
+            aria-invalid="${isInvalid ? 'true' : nothing}"
             aria-describedby="${ifDefined(isInvalid ? feedbackId : undefined)}"
             @change="${this._onFileInputChange}"
           />

--- a/packages/upload/src/it-upload.ts
+++ b/packages/upload/src/it-upload.ts
@@ -388,10 +388,6 @@ export class ItUpload extends FormControl {
     const showValidation = this.formControlController.submittedOnce;
     const isInvalid = showValidation && this.validationMessage.length > 0;
 
-    // Use the slotted label text as the input's accessible name so VoiceOver announces
-    // it correctly even though the <label> is aria-hidden (see below).
-    const accessibleName = this.label || labelText;
-
     return html`
       <div class="form-group">
         <input
@@ -403,15 +399,11 @@ export class ItUpload extends FormControl {
           accept="${ifDefined(this.accept)}"
           ?disabled="${this.disabled}"
           ?required="${this.required && this._files.length === 0}"
-          aria-label="${accessibleName}"
-          aria-required="${this.required ? 'true' : nothing}"
           aria-invalid="${isInvalid ? 'true' : 'false'}"
           aria-describedby="${ifDefined(isInvalid ? `invalid-feedback-${inputId}` : undefined)}"
           @change="${this._handleFileChange}"
         />
-        <!-- aria-hidden removes this label from the AT tree so VoiceOver only visits the
-             file input above, not both. The accessible name is carried by aria-label instead. -->
-        <label part="input-label" for="${inputId}" aria-hidden="true">
+        <label part="input-label" for="${inputId}">
           <slot name="icon">
             <it-icon
               name="${this.variant === 'gallery' ? 'it-plus' : 'it-upload'}"

--- a/packages/upload/src/it-upload.ts
+++ b/packages/upload/src/it-upload.ts
@@ -388,6 +388,10 @@ export class ItUpload extends FormControl {
     const showValidation = this.formControlController.submittedOnce;
     const isInvalid = showValidation && this.validationMessage.length > 0;
 
+    // Use the slotted label text as the input's accessible name so VoiceOver announces
+    // it correctly even though the <label> is aria-hidden (see below).
+    const accessibleName = this.label || labelText;
+
     return html`
       <div class="form-group">
         <input
@@ -399,11 +403,15 @@ export class ItUpload extends FormControl {
           accept="${ifDefined(this.accept)}"
           ?disabled="${this.disabled}"
           ?required="${this.required && this._files.length === 0}"
+          aria-label="${accessibleName}"
+          aria-required="${this.required ? 'true' : nothing}"
           aria-invalid="${isInvalid ? 'true' : 'false'}"
           aria-describedby="${ifDefined(isInvalid ? `invalid-feedback-${inputId}` : undefined)}"
           @change="${this._handleFileChange}"
         />
-        <label part="input-label" for="${inputId}">
+        <!-- aria-hidden removes this label from the AT tree so VoiceOver only visits the
+             file input above, not both. The accessible name is carried by aria-label instead. -->
+        <label part="input-label" for="${inputId}" aria-hidden="true">
           <slot name="icon">
             <it-icon
               name="${this.variant === 'gallery' ? 'it-plus' : 'it-upload'}"

--- a/packages/upload/src/it-upload.ts
+++ b/packages/upload/src/it-upload.ts
@@ -390,19 +390,13 @@ export class ItUpload extends FormControl {
 
     return html`
       <div class="form-group">
-        <input
-          type="file"
-          class="upload it-form__control"
-          id="${inputId}"
-          name="${this.name}"
-          ?multiple="${this.multiple}"
-          accept="${ifDefined(this.accept)}"
-          ?disabled="${this.disabled}"
-          ?required="${this.required && this._files.length === 0}"
-          aria-invalid="${isInvalid ? 'true' : 'false'}"
-          aria-describedby="${ifDefined(isInvalid ? `invalid-feedback-${inputId}` : undefined)}"
-          @change="${this._handleFileChange}"
-        />
+        <!-- Wrapping pattern per Scott O'Hara "Styled File Uploads":
+             https://scottaohara.github.io/a11y_styled_form_controls/src/file-upload/
+             Input inside label instead of BSI's sibling pattern (0.1px ghost input +
+             styled adjacent label). BSI's pattern makes VoiceOver visit the ghost as a
+             confusing "small square group" before the real button. With wrapping, both
+             stops are logical: label text → file upload control. No JS needed — click
+             propagation to the file picker is handled natively by the label. -->
         <label part="input-label" for="${inputId}">
           <slot name="icon">
             <it-icon
@@ -413,6 +407,19 @@ export class ItUpload extends FormControl {
             ></it-icon>
           </slot>
           <slot name="label">${labelText}</slot>
+          <input
+            type="file"
+            class="upload it-form__control"
+            id="${inputId}"
+            name="${this.name}"
+            ?multiple="${this.multiple}"
+            accept="${ifDefined(this.accept)}"
+            ?disabled="${this.disabled}"
+            ?required="${this.required && this._files.length === 0}"
+            aria-invalid="${isInvalid ? 'true' : 'false'}"
+            aria-describedby="${ifDefined(isInvalid ? `invalid-feedback-${inputId}` : undefined)}"
+            @change="${this._handleFileChange}"
+          />
         </label>
 
         ${when(this.supportText, () => html`<small class="form-text">${this.supportText}</small>`)}

--- a/packages/upload/src/it-upload.ts
+++ b/packages/upload/src/it-upload.ts
@@ -416,7 +416,7 @@ export class ItUpload extends FormControl {
             accept="${ifDefined(this.accept)}"
             ?disabled="${this.disabled}"
             ?required="${this.required && this._files.length === 0}"
-            aria-invalid="${isInvalid ? 'true' : 'false'}"
+            aria-invalid="${isInvalid ? 'true' : nothing}"
             aria-describedby="${ifDefined(isInvalid ? `invalid-feedback-${inputId}` : undefined)}"
             @change="${this._handleFileChange}"
           />

--- a/packages/upload/src/upload.scss
+++ b/packages/upload/src/upload.scss
@@ -40,10 +40,13 @@ utilities.$utilities: (
 
 @use 'bootstrap-italia/src/scss/base/utilities/api' as *;
 
-.upload[type='file'] + label {
+// Wrapped pattern (Scott O'Hara): input is inside the label, so BSI's adjacent-sibling
+// selectors (`input + label`) no longer match. We own all label styling here.
+// Ref: https://scottaohara.github.io/a11y_styled_form_controls/src/file-upload/
+label:has(.upload[type='file']) {
   display: flex;
   width: fit-content;
-  max-width: unset !important; // Override BSI's `label { max-width: 80% }` for the upload label, which needs to shrink to fit its content.
+  max-width: unset !important; // Override BSI's `label { max-width: 80% }`.
   align-items: center;
   gap: var(--#{$prefix}spacing-xxs, 8px);
 }
@@ -68,7 +71,7 @@ utilities.$utilities: (
 }
 
 :focus-visible,
-.upload:focus-visible + label,
+label:has(.upload[type='file']:focus-visible),
 .upload-dragdrop-input:focus-visible[type='file'] + label,
 .avatar-upload:focus-within:focus-visible {
   border-color: #000 !important;
@@ -77,6 +80,15 @@ utilities.$utilities: (
     0 0 0 5px $focus-outline-color-out !important;
   outline: 3px solid rgba(0, 0, 0, 0) !important;
   outline-offset: 3px !important;
+}
+
+// The bare :focus-visible rule above would apply to the 0.1px input itself when
+// it receives focus. Reset it so only the wrapping label shows the focus ring.
+.upload[type='file']:focus-visible {
+  border-color: initial !important;
+  box-shadow: none !important;
+  outline: none !important;
+  outline-offset: initial !important;
 }
 
 // Success state: check indicator + remove button grouped on the right
@@ -108,7 +120,7 @@ utilities.$utilities: (
   }
 }
 
-.upload-pictures-wall .upload[type='file'] + label {
+.upload-pictures-wall label:has(.upload[type='file']) {
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
Fixes https://github.com/italia/dev-kit-italia/issues/77#issuecomment-4790241829

Rework HTML+CSS per risolvere la problematica segnalata, presente anche su BSI 3.x. Riferimento: https://scottaohara.github.io/a11y_styled_form_controls/src/file-upload/

