### PR TITLE
fix: megamenu focus, styles, and list a11y

### DIFF
--- a/.changeset/slick-boats-stare.md
+++ b/.changeset/slick-boats-stare.md
@@ -1,0 +1,7 @@
+---
+'@italia/dropdown': patch
+'@italia/megamenu': patch
+'@italia/header': patch
+---
+
+Fixed megamenu styles, focus and a11y axe tools

--- a/packages/dropdown/src/it-dropdown-base.ts
+++ b/packages/dropdown/src/it-dropdown-base.ts
@@ -105,7 +105,11 @@ export class ItDropdownBase extends BaseComponent {
       if (this.itRole === 'menu') item.itRole = 'menuitem';
       else if (this.itRole === 'listbox') item.itRole = 'option';
       else if (this.itRole === 'tree') item.itRole = 'treeitem';
-      else item.itRole = undefined;
+      else if (this.itRole === 'list') {
+        // set role to 'listitem' to fix axe tools alert, and force itRole to 'presentation' to avoid duplicate roles in the megamenu
+        item.itRole = 'presentation';
+        item.role = 'listitem';
+      } else item.itRole = undefined;
     }
   }
 

--- a/packages/dropdown/src/it-dropdown-item.ts
+++ b/packages/dropdown/src/it-dropdown-item.ts
@@ -40,7 +40,7 @@ export class ItDropdownItem extends BaseComponent {
 
   override render() {
     if (this.separator) {
-      return html`<li><span class="divider" role="separator"></span></li>`;
+      return html`<li part="li"><span class="divider" role="separator"></span></li>`;
     }
 
     const itemClasses = this.composeClass({
@@ -75,7 +75,7 @@ export class ItDropdownItem extends BaseComponent {
         role="${ifDefined(itemRole)}"
         class=${ifDefined(itemClasses || undefined)}
         tabindex=${ifDefined(this.href ? undefined : '-1')}
-        part=${ifDefined(this.href ? undefined : 'focusable')}
+        part=${ifDefined(this.href ? 'li' : 'focusable li')}
         @keydown=${this.href ? undefined : this.handlePress}
         @click=${this.href ? undefined : this.handlePress}
         aria-disabled=${ifDefined((this.disabled && !this.href) || undefined)}

--- a/packages/dropdown/src/it-dropdown-item.ts
+++ b/packages/dropdown/src/it-dropdown-item.ts
@@ -24,7 +24,7 @@ export class ItDropdownItem extends BaseComponent {
 
   @property({ type: Boolean, attribute: 'full-width', reflect: true }) fullWidth = false;
 
-  @property({ type: String, attribute: 'it-role' }) itRole?: 'menuitem' | 'option' | 'treeitem';
+  @property({ type: String, attribute: 'it-role' }) itRole?: 'menuitem' | 'option' | 'treeitem' | 'presentation';
 
   @property({ type: Boolean, reflect: true }) disabled?: boolean;
 
@@ -49,8 +49,8 @@ export class ItDropdownItem extends BaseComponent {
       'list-item dropdown-item': !this.href,
     });
 
-    const itemRole = this.href && this.itRole ? 'none' : this.itRole;
-
+    const itemRole = this.href && this.itRole && this.itRole !== 'presentation' ? 'none' : this.itRole;
+    const hrefRole = this.href && this.itRole && this.itRole !== 'presentation' ? this.itRole : undefined;
     const statusClasses = this.composeClass({
       disabled: this.disabled,
       active: this.active,
@@ -85,7 +85,7 @@ export class ItDropdownItem extends BaseComponent {
               class=${linkClasses}
               part="focusable list-item"
               href=${this.href}
-              role=${ifDefined(this.itRole)}
+              role=${ifDefined(hrefRole)}
               aria-disabled=${ifDefined(this.disabled || undefined)}
               @keydown=${this.handlePress}
               @click=${this.handlePress}

--- a/packages/header/styles/globals.scss
+++ b/packages/header/styles/globals.scss
@@ -154,15 +154,16 @@
 
     it-dropdown,
     it-megamenu {
-      --#{$prefix}label-font-size: var(--#{$prefix}navbar-link-font-size);
-
       &,
       &::part(dropdown-popover),
       &::part(dropdown-button) {
         height: 100%;
       }
 
+
+
       &::part(dropdown-button) {
+        --#{$prefix}label-font-size: var(--#{$prefix}navbar-link-font-size);
         background-color: var(--#{$prefix}navbar-background); //to avoid color contrast issue from tools a11y checker
         color: var(--#{$prefix}navbar-link-color); //to avoid color contrast issue from tools a11y checker
       }
@@ -177,6 +178,7 @@
         --#{$prefix}btn-text-color: var(--#{$prefix}navbar-link-color);
         --#{$prefix}btn-padding-y: var(--#{$prefix}navbar-link-padding-y);
         --#{$prefix}btn-line-height: var(--#{$prefix}navbar-link-line-height);
+        --#{$prefix}label-font-size: var(--#{$prefix}navbar-link-font-size);
         border-left: var(--#{$prefix}navbar-link-border-size) solid var(--#{$prefix}navbar-link-border-color);
 
         &:hover {

--- a/packages/header/styles/globals.scss
+++ b/packages/header/styles/globals.scss
@@ -258,6 +258,10 @@ it-modal#it-nav-modal {
     position: unset; //per posizionare il bottone di chiusura sul backdrop
   }
 
+  &::part(modal-footer) {
+    display: none;
+  }
+
   .custom-navbar-toggler {
     --#{$prefix}icon-default: var(--#{$prefix}header-center-text-color);
     margin-top: 0;

--- a/packages/megamenu/src/it-megamenu.ts
+++ b/packages/megamenu/src/it-megamenu.ts
@@ -63,9 +63,6 @@ export class ItMegamenu extends ItDropdownBase {
     // disable full-width for dropdown items inside megamenu to let them inherit the width of their container and not stretch to the full width of the megamenu
     for (const item of this._menuItems) {
       item.fullWidth = false;
-      if (this.itRole === 'list') {
-        item.role = 'listitem';
-      }
     }
 
     this._syncClickCloseTargets();

--- a/packages/megamenu/src/it-megamenu.ts
+++ b/packages/megamenu/src/it-megamenu.ts
@@ -297,7 +297,9 @@ export class ItMegamenu extends ItDropdownBase {
                           <ul
                             class="link-list"
                             part="megamenu-link-list"
-                            style="columns: ${this.columns};"
+                            style="grid-template-rows: repeat(${Math.ceil(
+                              this._menuItems.length / this.columns,
+                            )}, auto);"
                             role=${ifDefined(this.itRole !== 'list' ? this.itRole : undefined)}
                           >
                             <slot @slotchange=${this._setChildrenProperties}></slot>

--- a/packages/megamenu/src/megamenu.scss
+++ b/packages/megamenu/src/megamenu.scss
@@ -51,12 +51,11 @@ utilities.$utilities: (
     @include media-breakpoint-up(lg) {
       --#{$prefix}dropdown-padding-y: var(--#{$prefix}spacing-m);
       --#{$prefix}dropdown-padding-x: var(--#{$prefix}spacing-xs);
-    }
 
-    .link-list-wrapper ul.link-list {
-      display: block;
-      column-gap: var(--#{$prefix}spacing-s);
-      /* spazio tra colonne */
+      .link-list-wrapper ul.link-list {
+        display: grid;
+        grid-auto-flow: column;
+      }
     }
 
     // .it-heading-link-wrapper {

--- a/packages/megamenu/styles/globals.scss
+++ b/packages/megamenu/styles/globals.scss
@@ -57,25 +57,6 @@ it-megamenu {
     }
   }
 
-  it-dropdown-item {
-    &::part(list-item) {
-      position: unset;
-      width: 100%;
-
-      &:focus-visible {
-        display: block; //to avoid safari shift on focus last column items
-      }
-    }
-
-    &::part(li) {
-      display: inline-block;
-      padding: 6px;
-      margin: -6px;
-      break-inside: avoid;
-      page-break-inside: avoid;
-    }
-  }
-
   @include media-breakpoint-up(lg) {
     &[footer-position='right'] {
       [slot='footer'] {

--- a/packages/megamenu/styles/globals.scss
+++ b/packages/megamenu/styles/globals.scss
@@ -40,7 +40,7 @@ it-megamenu {
 
     p {
       font-size: var(--#{$prefix}label-font-size);
-      line-height: var(--#{$prefix}body-leading);
+      line-height: var(--#{$prefix}body-line-height);
     }
   }
 
@@ -61,6 +61,18 @@ it-megamenu {
     &::part(list-item) {
       position: unset;
       width: 100%;
+
+      &:focus-visible {
+        display: block; //to avoid safari shift on focus last column items
+      }
+    }
+
+    &::part(li) {
+      display: inline-block;
+      padding: 6px;
+      margin: -6px;
+      break-inside: avoid;
+      page-break-inside: avoid;
     }
   }
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #51  https://github.com/italia/dev-kit-italia/issues/51#issuecomment-4461277022

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Sistemati i problemi rilevati in questo commento https://github.com/italia/dev-kit-italia/issues/51#issuecomment-4461277022




#### Changes proposed in this Pull Request:

In particolare, è stato aggiunto un fix a `it-dropdown-base`, per rimuovere una segnalazione di Axe tools, che, anche se un falso positivo poteva creare noie. 
In pratica, essendo `<ul>` e `<li>` generati da due shadowdom diversi, axe non vedeva gli `<li>` generati dallo shadowdom come figli di un `>ul>`. Pertanto il trucco è stato quello di assegnare all'`<li>` generato dallo shadowdom il `role="presentation"`, e assegnare al tag `it-dropdown-it` il role corretto. 
@pnicolli 
