### PR TITLE
fix(dropdown): closing on second click when nested in another shadow DOM

### DIFF
--- a/.changeset/tidy-plums-shave.md
+++ b/.changeset/tidy-plums-shave.md
@@ -1,0 +1,5 @@
+---
+'@italia/dropdown': patch
+---
+
+Fixed dropdown not closing on a second click of its trigger when nested inside another component's shadow DOM (e.g. `it-toolbar-item`'s toolbar dropdown)

--- a/packages/dropdown/src/it-dropdown-base.ts
+++ b/packages/dropdown/src/it-dropdown-base.ts
@@ -210,7 +210,11 @@ export class ItDropdownBase extends BaseComponent {
   }
 
   private _onDocumentClick = (event: MouseEvent) => {
-    if (this._popoverOpen && !this.contains(event.target as Node)) {
+    // Use composedPath() instead of event.target: when this dropdown is nested inside
+    // another shadow DOM host (e.g. it-toolbar-item), the target seen at the document
+    // level is retargeted to that outer host, so `this.contains(event.target)` would
+    // always be false and immediately close the dropdown right after opening it.
+    if (this._popoverOpen && !event.composedPath().includes(this)) {
       this._popoverOpen = false;
     }
   };

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -56,6 +56,7 @@
     "@italia/button": "workspace:^",
     "@italia/icon": "workspace:^",
     "@italia/dropdown": "workspace:^",
+    "@italia/popover": "workspace:^",
     "@open-wc/testing": "catalog:",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.2",

--- a/packages/toolbar/test/it-toolbar.test.ts
+++ b/packages/toolbar/test/it-toolbar.test.ts
@@ -1,7 +1,11 @@
 /// <reference types="mocha"/>
 
 import '@italia/toolbar';
-import { expect, fixture, html } from '@open-wc/testing';
+import '@italia/button';
+import '@italia/dropdown';
+import '@italia/popover';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { type LitElement } from 'lit';
 
 import { type ItToolbar } from '@italia/toolbar';
 
@@ -123,6 +127,34 @@ describe('Toolbar component', () => {
       const el = await fixture<ItToolbar>(html`<it-toolbar></it-toolbar>`);
       const nav = el.shadowRoot?.querySelector('nav');
       expect(nav?.classList.contains('toolbar')).to.be.true;
+    });
+  });
+
+  describe('dropdown item', () => {
+    it('toggles the dropdown open and closed on repeated trigger clicks (#430, #384)', async () => {
+      const el = await fixture<ItToolbar>(html`
+        <it-toolbar>
+          <it-toolbar-item dropdown label="Documenti" icon="it-file">
+            <it-dropdown-item slot="items" href="#">Azione 1</it-dropdown-item>
+          </it-toolbar-item>
+        </it-toolbar>
+      `);
+      const toolbarItem = el.querySelector('it-toolbar-item') as LitElement;
+      await toolbarItem.updateComplete;
+      const dropdown = toolbarItem.shadowRoot!.querySelector('it-dropdown') as LitElement;
+      await dropdown.updateComplete;
+      const button = (dropdown.shadowRoot!.querySelector('it-button') as LitElement).shadowRoot!.querySelector(
+        'button',
+      )!;
+      const popover = dropdown.shadowRoot!.querySelector('it-popover')!;
+
+      button.click();
+      await oneEvent(popover, 'it-popover-open');
+      expect(popover.hasAttribute('open')).to.be.true;
+
+      button.click();
+      await oneEvent(popover, 'it-popover-close');
+      expect(popover.hasAttribute('open')).to.be.false;
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2683,6 +2683,9 @@ importers:
       '@italia/icon':
         specifier: workspace:^
         version: link:../icon
+      '@italia/popover':
+        specifier: workspace:^
+        version: link:../popover
       '@italia/test-config':
         specifier: workspace:^
         version: link:../test-config


### PR DESCRIPTION
Fixes: #430 and #384

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Nella Toolbar (e in ogni altro componente che incapsula `it-dropdown` nel proprio shadow DOM), il click sul trigger apriva correttamente la dropdown ma un secondo click non la richiudeva più.

**Causa**: `it-dropdown-base` intercettava i click sul `document` e usava `this.contains(event.target)` per capire se il click fosse avvenuto fuori dal componente e quindi chiudere il popover. Quando `it-dropdown` è annidato dentro un altro elemento con proprio shadow DOM (es. `it-toolbar-item`), il browser fa il "retargeting" di `event.target` all'host più esterno: il controllo `contains()` risultava quindi sempre `false`, anche cliccando sul trigger stesso. Ogni click chiudeva forzatamente il popover un istante prima che il suo stesso handler di toggle lo riaprisse, rendendo impossibile chiuderlo.

**Fix**: sostituito il controllo con `event.composedPath().includes(this)`, coerente con la logica già usata da `it-popover`, che funziona correttamente attraverso i confini di più shadow DOM annidati.

#### Changes

- `packages/dropdown/src/it-dropdown-base.ts`: fix del listener `_onDocumentClick`
- `packages/toolbar/test/it-toolbar.test.ts`: nuovo test di regressione che riproduce lo scenario Toolbar → dropdown annidata, verifica apertura/chiusura su click ripetuti
- `packages/toolbar/package.json` / `pnpm-lock.yaml`: aggiunta `@italia/popover` come devDependency di test (necessaria per registrare i custom element nel nuovo test)
- Changeset patch per `@italia/dropdown`

Confermato inoltre che l'altro punto sollevato in #384 (l'attributo `dropdown` di `it-toolbar-item` dovrebbe essere booleano e non stringa vuota) è già stato risolto in un commit precedente: it-toolbar-item's dropdown property è già `@property({ type: Boolean, reflect: true })`, nulla da fare, la resa stringa vuota è comportamento nativo di Lit e dei browser.
