### PR TITLE
feat(avatar): add tooltip support for avatar links

### DIFF
--- a/.changeset/quiet-hounds-listen.md
+++ b/.changeset/quiet-hounds-listen.md
@@ -1,0 +1,5 @@
+---
+'@italia/tooltip': patch
+---
+
+Fix `it-tooltip` host to use `display: inline-flex` instead of the browser default inline box, so it stays vertically aligned with sibling elements when used as a flex item (e.g. wrapping an `it-avatar` in a row of avatars).

--- a/.changeset/tame-otters-smile.md
+++ b/.changeset/tame-otters-smile.md
@@ -1,0 +1,9 @@
+---
+'@italia/avatar': minor
+---
+
+Add tooltip support for avatar links: wrap `it-avatar` in `it-tooltip` (using its `trigger`/`content` slots) to show contextual info on hover/focus, matching the Bootstrap Italia "Avatar link con tooltip" pattern.
+
+- `it-avatar` now forwards `it-aria-*` attributes to its rendered `<a>`/`<div>`, so `it-tooltip` can wire up `aria-describedby` on the real link.
+- Fixed `it-avatar ~ span` CSS rules that were unintentionally applying list-item spacing to any sibling `<span>`, including a tooltip's `slot="content"` element.
+- Added a new, separate "Avatar link con tooltip" story/example section (kept distinct from the plain "Avatar con link" section) across Storybook and all framework examples.

--- a/examples/angular-app/src/app/pages/avatar.component.html
+++ b/examples/angular-app/src/app/pages/avatar.component.html
@@ -41,6 +41,25 @@
     </div>
   </section>
 
+  <!-- Avatar come link con tooltip -->
+  <section>
+    <h2>Avatar come link con tooltip</h2>
+    <div style="display: flex; gap: 1rem; align-items: center; justify-content: center; flex-wrap: wrap;">
+      <it-tooltip placement="left">
+        <it-avatar slot="trigger" type="image" src="https://randomuser.me/api/portraits/women/41.jpg" alt="Anna Barbieri" href="#" avatar-title="Anna Barbieri"></it-avatar>
+        <span slot="content"><strong>Anna Barbieri</strong><br /><em>Amministratore</em></span>
+      </it-tooltip>
+      <it-tooltip placement="top">
+        <it-avatar slot="trigger" type="text" text="Mario Rossi" href="#" avatar-title="Mario Rossi"></it-avatar>
+        <span slot="content"><strong>Mario Rossi</strong><br /><em>Editor</em></span>
+      </it-tooltip>
+      <it-tooltip placement="right">
+        <it-avatar slot="trigger" type="icon" icon="it-search" href="#" avatar-title="Cerca"></it-avatar>
+        <span slot="content"><strong>Cerca</strong><br /><em>Archivio notizie</em></span>
+      </it-tooltip>
+    </div>
+  </section>
+
   <!-- Comportamento - Presenza utente -->
   <section>
     <h2>Comportamento - Presenza utente</h2>

--- a/examples/react-app/src/pages/Avatar.jsx
+++ b/examples/react-app/src/pages/Avatar.jsx
@@ -116,6 +116,43 @@ export default function AvatarDemo() {
           <it-avatar type="icon" icon="it-user" href="#" avatar-title="Utente"></it-avatar>
         </div>
       </section>
+      {/* Avatar come link con tooltip */}
+      <section>
+        <h2>Avatar come link con tooltip</h2>
+        <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', justifyContent: 'center', flexWrap: 'wrap' }}>
+          <it-tooltip placement="left">
+            <it-avatar
+              slot="trigger"
+              type="image"
+              src="https://randomuser.me/api/portraits/women/41.jpg"
+              alt="Anna Barbieri"
+              href="#"
+              avatar-title="Anna Barbieri"
+            ></it-avatar>
+            <span slot="content">
+              <strong>Anna Barbieri</strong>
+              <br />
+              <em>Amministratore</em>
+            </span>
+          </it-tooltip>
+          <it-tooltip placement="top">
+            <it-avatar slot="trigger" type="text" text="Mario Rossi" href="#" avatar-title="Mario Rossi"></it-avatar>
+            <span slot="content">
+              <strong>Mario Rossi</strong>
+              <br />
+              <em>Editor</em>
+            </span>
+          </it-tooltip>
+          <it-tooltip placement="right">
+            <it-avatar slot="trigger" type="icon" icon="it-search" href="#" avatar-title="Cerca"></it-avatar>
+            <span slot="content">
+              <strong>Cerca</strong>
+              <br />
+              <em>Archivio notizie</em>
+            </span>
+          </it-tooltip>
+        </div>
+      </section>
       {/* Comportamento presenza utente */}
       <section>
         <h2>Comportamento presenza utente</h2>

--- a/examples/svelte-app/src/pages/Avatar.svelte
+++ b/examples/svelte-app/src/pages/Avatar.svelte
@@ -74,6 +74,32 @@
   </div>
 </section>
 
+<!-- Avatar come link con tooltip -->
+<section>
+  <h2>Avatar come link con tooltip</h2>
+  <div style="display: flex; gap: 1rem; align-items: center; justify-content: center; flex-wrap: wrap;">
+    <it-tooltip placement="left">
+      <it-avatar
+        slot="trigger"
+        type="image"
+        src="https://randomuser.me/api/portraits/women/41.jpg"
+        alt="Anna Barbieri"
+        href="#"
+        avatar-title="Anna Barbieri"
+      ></it-avatar>
+      <span slot="content"><strong>Anna Barbieri</strong><br /><em>Amministratore</em></span>
+    </it-tooltip>
+    <it-tooltip placement="top">
+      <it-avatar slot="trigger" type="text" text="Mario Rossi" href="#" avatar-title="Mario Rossi"></it-avatar>
+      <span slot="content"><strong>Mario Rossi</strong><br /><em>Editor</em></span>
+    </it-tooltip>
+    <it-tooltip placement="right">
+      <it-avatar slot="trigger" type="icon" icon="it-search" href="#" avatar-title="Cerca"></it-avatar>
+      <span slot="content"><strong>Cerca</strong><br /><em>Archivio notizie</em></span>
+    </it-tooltip>
+  </div>
+</section>
+
 <!-- Comportamento presenza utente -->
 <section>
   <h2>Comportamento presenza utente</h2>

--- a/examples/vanilla-app/src/avatar.html
+++ b/examples/vanilla-app/src/avatar.html
@@ -83,6 +83,25 @@
             </div>
           </section>
 
+          <!-- Avatar come link con tooltip -->
+          <section>
+            <h2>Avatar come link con tooltip</h2>
+            <div style="display:flex;gap:1rem;align-items:center;justify-content:center;flex-wrap:wrap;">
+              <it-tooltip placement="left">
+                <it-avatar slot="trigger" type="image" src="https://randomuser.me/api/portraits/women/41.jpg" alt="Anna Barbieri" href="#" avatar-title="Anna Barbieri"></it-avatar>
+                <span slot="content"><strong>Anna Barbieri</strong><br /><em>Amministratore</em></span>
+              </it-tooltip>
+              <it-tooltip placement="top">
+                <it-avatar slot="trigger" type="text" text="Mario Rossi" href="#" avatar-title="Mario Rossi"></it-avatar>
+                <span slot="content"><strong>Mario Rossi</strong><br /><em>Editor</em></span>
+              </it-tooltip>
+              <it-tooltip placement="right">
+                <it-avatar slot="trigger" type="icon" icon="it-search" href="#" avatar-title="Cerca"></it-avatar>
+                <span slot="content"><strong>Cerca</strong><br /><em>Archivio notizie</em></span>
+              </it-tooltip>
+            </div>
+          </section>
+
           <!-- Comportamento - Presenza utente -->
           <section>
             <h2>Comportamento - Presenza utente</h2>

--- a/examples/vue-app/src/components/Avatar.vue
+++ b/examples/vue-app/src/components/Avatar.vue
@@ -114,6 +114,32 @@ const imageAvatars = [
     </div>
   </section>
 
+  <!-- Avatar come link con tooltip -->
+  <section>
+    <h2>Avatar come link con tooltip</h2>
+    <div style="display: flex; gap: 1rem; align-items: center; justify-content: center; flex-wrap: wrap">
+      <it-tooltip placement="left">
+        <it-avatar
+          slot="trigger"
+          type="image"
+          src="https://randomuser.me/api/portraits/women/41.jpg"
+          alt="Anna Barbieri"
+          href="#"
+          avatar-title="Anna Barbieri"
+        />
+        <span slot="content"><strong>Anna Barbieri</strong><br /><em>Amministratore</em></span>
+      </it-tooltip>
+      <it-tooltip placement="top">
+        <it-avatar slot="trigger" type="text" text="Mario Rossi" href="#" avatar-title="Mario Rossi" />
+        <span slot="content"><strong>Mario Rossi</strong><br /><em>Editor</em></span>
+      </it-tooltip>
+      <it-tooltip placement="right">
+        <it-avatar slot="trigger" type="icon" icon="it-search" href="#" avatar-title="Cerca" />
+        <span slot="content"><strong>Cerca</strong><br /><em>Archivio notizie</em></span>
+      </it-tooltip>
+    </div>
+  </section>
+
   <!-- Comportamento presenza utente -->
   <section>
     <h2>Comportamento presenza utente</h2>

--- a/packages/avatar/src/it-avatar.ts
+++ b/packages/avatar/src/it-avatar.ts
@@ -1,4 +1,4 @@
-import { BaseLocalizedComponent } from '@italia/globals';
+import { BaseLocalizedComponent, setAttributes } from '@italia/globals';
 import { html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -356,6 +356,7 @@ export class ItAvatar extends BaseLocalizedComponent {
               class="${this.getAvatarWrapperClasses()}"
               title="${ifDefined(this.avatarTitle || this.text || undefined)}"
               part="avatar focusable"
+              ${setAttributes(this._ariaAttributes)}
             >
               ${avatarContent}
             </a>

--- a/packages/avatar/stories/it-avatar.mdx
+++ b/packages/avatar/stories/it-avatar.mdx
@@ -67,11 +67,22 @@ Per mostrare un'icona all'interno di un avatar, usa l'attributo `icon` valorizza
 
 Per associare un avatar a un'azione o un link, usa l'attributo `href` con relativo link o chiamata JavaScript.
 
-<div class="callout callout-warning"><div class="callout-inner"><div class="callout-title"><span class="text">Tooltip non ancora implementato</span></div>
-<p>La funzionalità tooltip per gli avatar con link è attualmente in fase di sviluppo.</p></div></div>
-
 <Canvas of={AvatarStories.AvatarLink} />
 
+## Avatar link con tooltip
+
+È possibile associare un tooltip con maggiori informazioni relative all'utente o all'azione associata utilizzando il [componente tooltip](/docs/componenti-tooltip--documentazione).
+
+Per farlo, avvolgi l'avatar in un componente `it-tooltip`: inserisci l'avatar nello slot `trigger` e il testo del tooltip nello slot `content`.
+
+```html
+<it-tooltip placement="left">
+	<it-avatar slot="trigger" src="..." alt="Anna Barbieri" href="#" avatar-title="Anna Barbieri"></it-avatar>
+	<span slot="content"><strong>Anna Barbieri</strong><br /><em>Amministratore</em></span>
+</it-tooltip>
+```
+
+<Canvas of={AvatarStories.AvatarLinkConTooltip} />
 
 ## Presenza utente
 

--- a/packages/avatar/stories/it-avatar.stories.ts
+++ b/packages/avatar/stories/it-avatar.stories.ts
@@ -485,10 +485,6 @@ export const AvatarLink: Story = {
       description: {
         story: `
 Per associare un avatar ad un'azione o un link, utilizzare l'attributo \`href\` con relativo link o chiamata JavaScript.
-
-<div class="callout callout-warning"><div class="callout-inner"><div class="callout-title"><span class="text">Tooltip non ancora implementato</span></div>
-<p>La funzionalità tooltip per gli avatar con link è attualmente in fase di sviluppo.</p></div></div>
-
 `,
       },
     },
@@ -522,6 +518,69 @@ Per associare un avatar ad un'azione o un link, utilizzare l'attributo \`href\` 
           href: '#',
           avatarTitle: 'Utente',
         })}
+      </div>
+    </div>
+  `,
+};
+
+export const AvatarLinkConTooltip: Story = {
+  name: 'Avatar link con tooltip',
+  argTypes: {
+    href: { table: { disable: true } },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+È possibile associare un tooltip con maggiori informazioni relative all'utente o all'azione associata utilizzando il [componente tooltip](/docs/componenti-tooltip--documentazione).
+
+Per farlo, avvolgere l'avatar in un componente \`it-tooltip\`: inserire l'avatar nello slot \`trigger\` e il testo del tooltip nello slot \`content\`.
+
+\`\`\`html
+<it-tooltip placement="left">
+  <it-avatar slot="trigger" src="..." alt="Anna Barbieri" href="#" avatar-title="Anna Barbieri"></it-avatar>
+  <span slot="content"><strong>Anna Barbieri</strong><br /><em>Amministratore</em></span>
+</it-tooltip>
+\`\`\`
+`,
+      },
+    },
+  },
+  decorators: [(story) => html`<div style="padding:60px 0 20px;">${story()}</div>`],
+  render: () => html`
+    <div>
+      <div class="d-flex align-items-center gap-3 flex-wrap">
+        <it-tooltip placement="left">
+          ${renderComponent({
+            type: 'image',
+            src: 'https://randomuser.me/api/portraits/women/41.jpg',
+            alt: 'Anna Barbieri',
+            href: '#',
+            avatarTitle: 'Anna Barbieri',
+            slot: 'trigger',
+          })}
+          <span slot="content"><strong>Anna Barbieri</strong><br /><em>Amministratore</em></span>
+        </it-tooltip>
+        <it-tooltip placement="top">
+          ${renderComponent({
+            type: 'text',
+            text: 'Mario Rossi',
+            href: '#',
+            avatarTitle: 'Mario Rossi',
+            slot: 'trigger',
+          })}
+          <span slot="content"><strong>Mario Rossi</strong><br /><em>Editor</em></span>
+        </it-tooltip>
+        <it-tooltip placement="right">
+          ${renderComponent({
+            type: 'icon',
+            icon: 'it-search',
+            href: '#',
+            avatarTitle: 'Cerca',
+            slot: 'trigger',
+          })}
+          <span slot="content"><strong>Cerca</strong><br /><em>Archivio notizie</em></span>
+        </it-tooltip>
       </div>
     </div>
   `,

--- a/packages/avatar/styles/globals.scss
+++ b/packages/avatar/styles/globals.scss
@@ -71,7 +71,7 @@ it-avatar[size='xxl'] {
   --#{$prefix}avatar-size: 7rem;
 }
 
-it-avatar ~ span {
+it-avatar ~ span:not([slot]) {
   margin-left: var(--#{$prefix}spacing-xxs);
 }
 
@@ -113,7 +113,7 @@ ul.avatar-group-stacked {
 }
 
 ul li {
-  it-avatar ~ span {
+  it-avatar ~ span:not([slot]) {
     margin-left: var(--#{$prefix}spacing-xxs);
   }
 

--- a/packages/tooltip/src/tooltip.scss
+++ b/packages/tooltip/src/tooltip.scss
@@ -6,6 +6,11 @@
 @use 'bootstrap-italia/src/scss/base/transitions' as *;
 @use 'bootstrap-italia/src/scss/components/tooltip' as *;
 
+:host {
+  display: inline-flex;
+  align-items: center;
+}
+
 .tooltip {
   position: absolute;
   visibility: hidden;


### PR DESCRIPTION

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->



#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Wrap it-avatar in it-tooltip (trigger/content slots) to show contextual info on hover/focus, matching the Bootstrap Italia "Avatar link con tooltip" pattern as a section distinct from the plain "Avatar con link" one. it-avatar now forwards it-aria-* attributes to its rendered anchor/div so tooltip aria-describedby wiring works, and the `it-avatar ~ span` CSS rule no longer bleeds into slotted tooltip content. Also fixes it-tooltip's host display so it stays aligned with sibling elements in a flex row.
