### PR TITLE
fix(carousel): move aria-roledescription off the presentational shadow wrapper

### DIFF
--- a/.changeset/carousel-roledescription-issue-58.md
+++ b/.changeset/carousel-roledescription-issue-58.md
@@ -1,0 +1,5 @@
+---
+'@italia/carousel': patch
+---
+
+Fixed `aria-roledescription` being set on the shadow DOM wrapper, where it had no effect since that element carries `role="presentation"`. It is now set on the host element instead, next to the `region` landmark.

--- a/packages/carousel/src/it-carousel.ts
+++ b/packages/carousel/src/it-carousel.ts
@@ -264,6 +264,15 @@ export class ItCarousel extends BaseLocalizedComponent {
     // handleTitleSlotChange), so the inner div's landmark role is redundant and would
     // cause a landmark-unique Axe violation. Demote it to a generic container.
     this.wrapper?.setAttribute('role', 'presentation');
+    // Splide also sets aria-roledescription on the same div, but per the ARIA spec
+    // aria-roledescription has no effect (and shouldn't be used) on an element with
+    // role="presentation": the element is removed from the accessibility tree, so
+    // the roledescription would never be announced. Move it to the host, where the
+    // "region" landmark actually lives, for consistency with Bootstrap Italia.
+    this.wrapper?.removeAttribute('aria-roledescription');
+    if (!this.hasAttribute('aria-roledescription')) {
+      this.setAttribute('aria-roledescription', this.$t('carousel_carousel'));
+    }
   }
 
   override connectedCallback() {

--- a/packages/carousel/test/it-carousel.test.ts
+++ b/packages/carousel/test/it-carousel.test.ts
@@ -113,6 +113,19 @@ describe('it-carousel', () => {
       expect(el.getAttribute('role')).to.equal('region');
     });
 
+    it('host element has aria-roledescription and the shadow wrapper does not', async () => {
+      const el = await fixture<ItCarousel>(
+        html`<it-carousel
+          ><h3 slot="title">Titolo</h3>
+          <div>Slide 1</div></it-carousel
+        >`,
+      );
+      await splideReady();
+      expect(el.getAttribute('aria-roledescription')).to.equal('carousel');
+      const wrapper = el.shadowRoot?.querySelector('.it-carousel-wrapper');
+      expect(wrapper?.hasAttribute('aria-roledescription')).to.be.false;
+    });
+
     it('root element always has "it-carousel-wrapper" and "splide" classes', async () => {
       const el = await fixture<ItCarousel>(html`<it-carousel></it-carousel>`);
       const root = el.shadowRoot?.querySelector('.it-carousel-wrapper');


### PR DESCRIPTION

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/italia/dev-kit-italia/issues/58#issuecomment-4873564884

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Splide sets aria-roledescription on its root div unconditionally, but that div is demoted to role="presentation" to avoid a duplicate landmark, which makes the roledescription a no-op per the ARIA spec. Move it to the host element instead, next to the existing role="region" landmark.
