### PR TITLE
docs: rename Angular Universal to Angular SSR

### DIFF
--- a/packages/dev-kit-italia/stories/DocumentazioneTecnica.mdx
+++ b/packages/dev-kit-italia/stories/DocumentazioneTecnica.mdx
@@ -126,7 +126,7 @@ Vantaggi:
 
 <it-callout variant="primary" heading-level="h3">
   <span slot="title">NOTA</span>
-  <p>Per il comportamento del kit in ambienti con Server-Side Rendering (Next.js, SvelteKit, Nuxt, Angular Universal) e i pattern di importazione da usare in quei contesti, vedi la guida dedicata a [SSR](/docs/framework-ssr--documentazione).</p>
+  <p>Per il comportamento del kit in ambienti con Server-Side Rendering (Next.js, SvelteKit, Nuxt, Angular SSR) e i pattern di importazione da usare in quei contesti, vedi la guida dedicata a [SSR](/docs/framework-ssr--documentazione).</p>
 </it-callout>
 
 Esempio:

--- a/packages/dev-kit-italia/stories/frameworks/Angular.mdx
+++ b/packages/dev-kit-italia/stories/frameworks/Angular.mdx
@@ -33,7 +33,7 @@ Dev Kit Italia si integra nativamente con Angular tramite i Custom Elements stan
       <span class="text">SSR</span>
     </div>
     <p>
-      Se usi Angular con SSR abilitato (Angular Universal), l'import statico di <code>elements.js</code> mostrato di seguito va adattato: consulta la guida dedicata a <a href="/docs/framework-ssr--documentazione">SSR</a>.
+      Se usi Angular con SSR abilitato (Angular SSR), l'import statico di <code>elements.js</code> mostrato di seguito va adattato: consulta la guida dedicata a <a href="/docs/framework-ssr--documentazione">SSR</a>.
     </p>
   </div>
 </div>

--- a/packages/dev-kit-italia/stories/frameworks/SSR.mdx
+++ b/packages/dev-kit-italia/stories/frameworks/SSR.mdx
@@ -7,7 +7,7 @@ export const path = process.env.GH_PAGES_PATH + '/next-app/';
 
 # SSR (Server-Side Rendering)
 
-I pattern di importazione mostrati nelle altre pagine di questa sezione (`import '@italia/dev-kit-italia/elements.js'` nel punto di ingresso) assumono un contesto **client-only**, cioè un'applicazione senza SSR. In un'app con SSR abilitato — Next.js App Router, SvelteKit, Nuxt, Angular Universal — quello stesso import va sostituito con uno dei pattern descritti in questa pagina. Vedi [issue #360](https://github.com/italia/dev-kit-italia/issues/360).
+I pattern di importazione mostrati nelle altre pagine di questa sezione (`import '@italia/dev-kit-italia/elements.js'` nel punto di ingresso) assumono un contesto **client-only**, cioè un'applicazione senza SSR. In un'app con SSR abilitato — Next.js App Router, SvelteKit, Nuxt, Angular SSR — quello stesso import va sostituito con uno dei pattern descritti in questa pagina. Vedi [issue #360](https://github.com/italia/dev-kit-italia/issues/360).
 
 <div class="callout callout-warning">
   <div class="callout-inner">
@@ -98,9 +98,9 @@ Stesso principio, con `onMount` al posto di `useEffect`:
 <it-button>Cliccami</it-button>
 ```
 
-## Altri framework SSR (Nuxt, Angular Universal, Remix, ...)
+## Altri framework SSR (Nuxt, Angular SSR, Remix, ...)
 
-Il principio è lo stesso ovunque: registra i componenti in un hook lato client (`onMounted` in Nuxt, un guard su `isPlatformBrowser` o `afterNextRender` in Angular Universal, `useEffect`/`ClientOnly` in Remix), e mantieni il markup con gli slot statico nel template così che il server lo emetta comunque.
+Il principio è lo stesso ovunque: registra i componenti in un hook lato client (`onMounted` in Nuxt, un guard su `isPlatformBrowser` o `afterNextRender` in Angular SSR, `useEffect`/`ClientOnly` in Remix), e mantieni il markup con gli slot statico nel template così che il server lo emetta comunque.
 
 ## Internazionalizzazione
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #471 

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [X] My branch is up-to-date with the Upstream `main` branch.
- [ ] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Removing referencing to Angular Universal in documentation 

#### Changes proposed in this Pull Request:

- rename Angular Universal to Angular SSR

## <!-- You can use a few bullet points to describe some implementation changes proposed. For Example - feat: adding navbar component -->
