### PR TITLE
fix(bottom-nav): only highlight the active item's text color

### DIFF
--- a/.changeset/bottom-nav-active-color-468.md
+++ b/.changeset/bottom-nav-active-color-468.md
@@ -1,0 +1,5 @@
+---
+'@italia/bottom-nav': patch
+---
+
+Fixed active item text color in `it-bottom-nav-item` incorrectly applying to all items instead of only the active one

--- a/packages/bottom-nav/src/bottom-nav-item.scss
+++ b/packages/bottom-nav/src/bottom-nav-item.scss
@@ -18,18 +18,17 @@
 }
 
 ::slotted(a:hover) {
-  color: var(--#{$prefix}color-primary);
+  color: var(--#{$prefix}color-text-primary) !important;
   text-decoration: none !important;
 }
 
 :host([active]) ::slotted(a) {
-  color: var(--#{$prefix}color-primary);
+  color: var(--#{$prefix}color-text-primary) !important;
   --#{$prefix}icon-default: var(--#{$prefix}icon-primary);
 }
 
 :host ::slotted(a) {
   position: relative;
-  color: var(--#{$prefix}color-background-primary) !important;
   --#{$prefix}icon-default: var(--#{$prefix}icon-secondary);
 }
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #468

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

The unconditional :host ::slotted(a) rule set color to --color-background-primary with !important, overriding both the default secondary color and the active-state override so every item showed the same blue regardless of active state. The active/hover rules also referenced --color-primary, which isn't a real design token, so they silently resolved to nothing.
