### PR TITLE
fix: allineare it-card location a it-card-profile-content

### DIFF
--- a/.changeset/swift-deserts-ring.md
+++ b/.changeset/swift-deserts-ring.md
@@ -1,0 +1,5 @@
+---
+'@italia/card': patch
+---
+
+Fixed card profile content class

--- a/packages/card/src/it-card.ts
+++ b/packages/card/src/it-card.ts
@@ -302,7 +302,7 @@ export class ItCard extends BaseComponent {
       return html`
         <article class="${classes}" part="card">
           <div class="it-card-profile-header">
-            <div class="it-card-profile">
+            <div class="it-card-profile-content">
               ${cardTitle}
               ${hasSubtitle
                 ? html`

--- a/packages/card/stories/it-card.stories.ts
+++ b/packages/card/stories/it-card.stories.ts
@@ -1066,7 +1066,10 @@ export const ListeDiContenutiAffini: Story = {
         <it-card full-height ratio="21x9">
           <a slot="title" href="#">Titolo evento</a>
           <figure slot="image" class="figure img-full">
-            <img src="https://picsum.photos/seed/monument/800/600" alt="Breve descrizione immagine se ha senso nel contesto, marcare altrimenti come decorativa lasciando l'alt applicato ma vuoto.">
+            <img
+              src="https://picsum.photos/seed/monument/800/600"
+              alt="Breve descrizione immagine se ha senso nel contesto, marcare altrimenti come decorativa lasciando l'alt applicato ma vuoto."
+            />
           </figure>
           <span slot="subtitle">Dal 17 al 22 novembre</span>
           <span slot="text">Descrizione breve dell'evento in poche righe non troncate.</span>

--- a/packages/card/stories/it-card.stories.ts
+++ b/packages/card/stories/it-card.stories.ts
@@ -1086,7 +1086,7 @@ export const ListeDiContenutiAffini: Story = {
         </it-card>
       </div>
       <div class="col-12 col-md-6 col-lg-6 mb-3 mb-md-4">
-        <it-card full-height">
+        <it-card full-height>
           <a slot="title" href="#">Argomento X</a>
           <span slot="text">Descrizione breve dell'argomento in poche righe non troncate.</span>
           <ul slot="body" class="list-group list-group-flush" aria-label="Contenuti in evidenza:">


### PR DESCRIPTION
Refs italia/bootstrap-italia#1891

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Il div interno del wrapper (`it-card-profile-header` > primo figlio) nella variante `location` usava ancora `it-card-profile`, lo stesso nome bare dell'articolo esterno (via composeClass) — "double class" pre-#1566, mai corretta qui perché la variante `profile` fu allineata a suo tempo, `location` no.

bootstrap-italia#1891 rimuove `.it-card-profile` come nome bare dallo SCSS, consolidando i due blocchi paralleli persone/luoghi in `it-card-profile-content`. `it-card.scss` importa `components/card` di BSI direttamente, quindi lo SCSS si aggiorna da solo — ma questo file genera l'HTML con classe hardcoded, indipendente. Senza fix: al bump della dipendenza, le card `variant="location"` perdono silenziosamente lo styling del wrapper interno.

L'articolo esterno continua a portare `it-card-profile` (via composeClass, riga invariata) — quella è intenzionale, rispecchia la classe outer di BSI, non va toccata.

Verificato anche globals.scss e _fouc.scss del pacchetto: nessuno dei due referenzia questa classe, nessuna azione dovrebbe essere richiesta lì.