### PR TITLE
fix: pagination a11y tree

### DIFF
--- a/.changeset/fix-pagination-a11y-issue-514.md
+++ b/.changeset/fix-pagination-a11y-issue-514.md
@@ -1,0 +1,5 @@
+---
+'@italia/pagination': patch
+---
+
+Fixed pagination items role to expose a valid list structure in the accessibility tree

--- a/packages/pagination/src/it-pagination-item.ts
+++ b/packages/pagination/src/it-pagination-item.ts
@@ -9,6 +9,8 @@ export class ItPaginationItem extends BaseComponent {
 
   static shadowRootOptions = { ...BaseComponent.shadowRootOptions, delegatesFocus: true };
 
+  @property({ type: String, reflect: true, attribute: 'role' }) elRole = 'listitem';
+
   @property({ type: String, reflect: true })
   page = '';
 
@@ -82,7 +84,7 @@ export class ItPaginationItem extends BaseComponent {
     const liClasses = this.composeClass('page-item', this.current && 'active', this.disabled && 'disabled');
 
     return html`
-      <li class="${liClasses}">
+      <li class="${liClasses}" role="presentation">
         <slot @slotchange="${this.handleSlotChange}"></slot>
       </li>
     `;

--- a/packages/pagination/test/it-pagination.test.ts
+++ b/packages/pagination/test/it-pagination.test.ts
@@ -704,4 +704,52 @@ describe('it-pagination', () => {
       expect(visibleItems.length).to.be.at.most(5);
     });
   });
+
+  describe('accessibility', () => {
+    it('exposes a valid list structure in the accessibility tree', async () => {
+      const el = await fixture<ItPagination>(html`
+        <it-pagination value="3" it-aria-label="Navigazione pagine">
+          <a href="#" slot="prev"><span class="visually-hidden">Pagina precedente</span></a>
+          <it-pagination-item page="1"><a href="#">1</a></it-pagination-item>
+          <it-pagination-item page="2"><a href="#">2</a></it-pagination-item>
+          <it-pagination-item page="3"><a href="#">3</a></it-pagination-item>
+          <a href="#" slot="next"><span class="visually-hidden">Pagina successiva</span></a>
+        </it-pagination>
+      `);
+
+      await el.updateComplete;
+
+      await expect(el).to.be.accessible();
+
+      el.querySelectorAll('it-pagination-item').forEach((item) => {
+        expect(item.getAttribute('role')).to.equal('listitem');
+        expect(item.shadowRoot!.querySelector('li')!.getAttribute('role')).to.equal('presentation');
+      });
+    });
+
+    it('is accessible in simple mode', async () => {
+      const el = await fixture<ItPagination>(html`
+        <it-pagination value="2" total="10" simple-mode it-aria-label="Navigazione pagine">
+          <it-pagination-item page="1"><a href="#">1</a></it-pagination-item>
+          <it-pagination-item page="2"><a href="#">2</a></it-pagination-item>
+        </it-pagination>
+      `);
+
+      await el.updateComplete;
+      await expect(el).to.be.accessible();
+    });
+
+    it('is accessible with ellipsis (more mode)', async () => {
+      const el = await fixture<ItPagination>(html`
+        <it-pagination value="5" total="20" visible-pages="3" it-aria-label="Navigazione pagine">
+          ${[1, 2, 3, 4, 5, 6, 7].map(
+            (page) => html`<it-pagination-item page="${page}"><a href="#">${page}</a></it-pagination-item>`,
+          )}
+        </it-pagination>
+      `);
+
+      await el.updateComplete;
+      await expect(el).to.be.accessible();
+    });
+  });
 });


### PR DESCRIPTION
Closes #514

## Soluzione

Stesso intervento già applicato ai breadcrumbs (5e0ecfc6):

- l'host `it-pagination-item` riflette `role="listitem"` (tramite la property `elRole`, sovrascrivibile dal consumer)
- la `<li class="page-item …">` interna riceve `role="presentation"`

## Test

Aggiunti test di accessibilità (assert axe) sulle varianti con navigazione, `simple-mode` ed ellipsis/more mode, per prevenire regressioni sull'albero di accessibilità della lista.