### PR TITLE
docs: uniforma i riferimenti a tag HTML e classi CSS

### DIFF
--- a/packages/accordion/stories/it-accordion.mdx
+++ b/packages/accordion/stories/it-accordion.mdx
@@ -32,19 +32,19 @@ Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto
 
 Il componente Accordion è composto da due elementi:
 
-- `it-accordion`: contenitore che raggruppa più elementi richiudibili;
-- `it-accordion-item`: singolo elemento richiudibile all'interno dell'accordion.
+- `<it-accordion>`: contenitore che raggruppa più elementi richiudibili;
+- `<it-accordion-item>`: singolo elemento richiudibile all'interno dell'accordion.
 
 ## Elemento richiudibile
 
-`it-accordion-item` rappresenta il singolo elemento richiudibile all'interno dell'accordion.
+`<it-accordion-item>` rappresenta il singolo elemento richiudibile all'interno dell'accordion.
 
-Ogni `it-accordion-item` utilizza due slot distinti per definire intestazione e contenuto:
+Ogni `<it-accordion-item>` utilizza due slot distinti per definire intestazione e contenuto:
 
 - `slot="heading"`: **obbligatorio**, il testo da mostrare nell'header dell'elemento;
 - `slot="content"`: **obbligatorio**, il contenuto da mostrare o nascondere.
 
-Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto e il comportamento del componente `it-accordion-item`. Per vedere come cambia il codice, clicca su **Show code**.
+Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto e il comportamento del componente `<it-accordion-item>`. Per vedere come cambia il codice, clicca su **Show code**.
 
 <Canvas of={AccordionStories.AccordionItem} />
 <Controls of={AccordionStories.AccordionItem} />
@@ -73,7 +73,7 @@ Per abilitare la modalità esclusiva, assegna all'attributo `mode` il valore `si
 
 Gli elementi dell'accordion possono mostrare uno sfondo primario quando la sezione corrispondente è attiva (aperta).
 
-Per applicare lo sfondo primario agli elementi attivi, imposta l'attributo `background-active` sull'elemento `it-accordion`.
+Per applicare lo sfondo primario agli elementi attivi, imposta l'attributo `background-active` sull'elemento `<it-accordion>`.
 
 <Canvas of={AccordionStories.HeaderAttivi} />
 
@@ -81,7 +81,7 @@ Per applicare lo sfondo primario agli elementi attivi, imposta l'attributo `back
 
 Gli elementi dell'accordion possono mostrare uno sfondo primario al passaggio del mouse.
 
-Per applicare lo sfondo primario agli elementi al passaggio del mouse, imposta l'attributo `background-hover` sull'elemento `it-accordion`.
+Per applicare lo sfondo primario agli elementi al passaggio del mouse, imposta l'attributo `background-hover` sull'elemento `<it-accordion>`.
 
 <Canvas of={AccordionStories.HoverDegliHeader} />
 

--- a/packages/alert/stories/it-alert.mdx
+++ b/packages/alert/stories/it-alert.mdx
@@ -61,7 +61,7 @@ Per dare risalto a un link all'interno dell'alert, usa la classe `.alert-link`.
 
 Puoi aggiungere elementi HTML all'interno di un alert, come intestazioni, paragrafi e divisori.
 
-**Nota bene**: nell'esempio è stata usata l'intestazione `h4` soltanto a scopo dimostrativo.
+**Nota bene**: nell'esempio è stata usata l'intestazione `<h4>` soltanto a scopo dimostrativo.
 Usa sempre i tag di intestazione in modo coerente con la gerarchia dei contenuti della pagina che stai creando.
 
 <Canvas of={Stories.ContenutoAggiuntivo} />
@@ -113,4 +113,4 @@ Il componente espone i seguenti metodi e eventi accessibili via JavaScript.
 - `close()` — chiude l'alert con animazione di dissolvenza e lo rimuove dal DOM. Se presente, sposta il focus sul pulsante di chiusura dell'alert adiacente.
 
 ### Eventi
-- `it-alert-close` — emesso al click sul pulsante di chiusura. L'evento è cancellabile: chiamando `event.preventDefault()` si impedisce la rimozione automatica. Il `detail` contiene `alert`, riferimento all'elemento `it-alert` corrente.
+- `it-alert-close` — emesso al click sul pulsante di chiusura. L'evento è cancellabile: chiamando `event.preventDefault()` si impedisce la rimozione automatica. Il `detail` contiene `alert`, riferimento all'elemento `<it-alert>` corrente.

--- a/packages/autocomplete/stories/it-autocomplete.mdx
+++ b/packages/autocomplete/stories/it-autocomplete.mdx
@@ -8,7 +8,7 @@ import * as Stories from './it-autocomplete.stories';
 <description>Campo di input che suggerisce automaticamente opzioni di completamento man mano che l'utente digita.</description>
 
 ## Cosa fa
-Il componente Autocomplete (`it-autocomplete`) suggerisce opzioni di autocompletamento mentre l'utente digita in un campo input. I suggerimenti si basano sul testo inserito e aiutano l'utente a compilare rapidamente il campo senza dover scrivere il testo per intero.
+Il componente Autocomplete (`<it-autocomplete>`) suggerisce opzioni di autocompletamento mentre l'utente digita in un campo input. I suggerimenti si basano sul testo inserito e aiutano l'utente a compilare rapidamente il campo senza dover scrivere il testo per intero.
 
 [Approfondisci quando e come usare il componente Autocomplete](https://designers.italia.it/design-system/form/autocompletamento/)
 
@@ -71,7 +71,7 @@ L'etichetta sarà nascosta visivamente ma verrà letta dai lettori di schermo.
 
 ## Opzioni dinamiche
 
-Puoi far popolare dinamicamente le opzioni del componente `it-autocomplete` attraverso manipolazioni JavaScript e/o definendo una funzione da associare all'attributo `source` via JS. Il formato delle opzioni deve essere un array di oggetti con le proprietà `value` e `label`.
+Puoi far popolare dinamicamente le opzioni del componente `<it-autocomplete>` attraverso manipolazioni JavaScript e/o definendo una funzione da associare all'attributo `source` via JS. Il formato delle opzioni deve essere un array di oggetti con le proprietà `value` e `label`.
 
 ### Dati dipendenti da un altro input
 

--- a/packages/avatar/stories/it-avatar.mdx
+++ b/packages/avatar/stories/it-avatar.mdx
@@ -12,7 +12,7 @@ import * as AvatarStories from './it-avatar.stories';
 ## Cosa fa
 
 
-Il componente Avatar (`it-avatar`) permette di rappresentare una persona, il suo stato e le sue azioni in contesti di interazione.
+Il componente Avatar (`<it-avatar>`) permette di rappresentare una persona, il suo stato e le sue azioni in contesti di interazione.
 
 Può essere utile, ad esempio, per indicare l'autore di un testo, il proprio profilo in un'area riservata e le persone che hanno interagito con un contenuto.
 
@@ -73,7 +73,7 @@ Per associare un avatar a un'azione o un link, usa l'attributo `href` con relati
 
 È possibile associare un tooltip con maggiori informazioni relative all'utente o all'azione associata utilizzando il [componente tooltip](/docs/componenti-tooltip--documentazione).
 
-Per farlo, avvolgi l'avatar in un componente `it-tooltip`: inserisci l'avatar nello slot `trigger` e il testo del tooltip nello slot `content`.
+Per farlo, avvolgi l'avatar in un componente `<it-tooltip>`: inserisci l'avatar nello slot `trigger` e il testo del tooltip nello slot `content`.
 
 ```html
 <it-tooltip placement="left">
@@ -180,12 +180,12 @@ Per visualizzare una lista orizzontale di avatar parzialmente sovrapposti, racch
 
 Puoi utilizzare avatar di dimensione `sm` o `md` all'interno della lista.
 
-Per mostrare ulteriori avatar in un menu a discesa, usa `it-avatar` con `type="dropdown"`.
+Per mostrare ulteriori avatar in un menu a discesa, usa `<it-avatar>` con `type="dropdown"`.
 
 L'avatar dropdown eredita automaticamente la dimensione dal gruppo e può contenere una lista di avatar con nomi nel menu.
 
 <div class="callout callout-success"><div class="callout-inner"><div class="callout-title"><span class="text">Accessibilità del dropdown</span></div>
-<p>Usa l'attributo `it-aria-label` sul componente `it-dropdown` per fornire una descrizione completa agli screen reader. L'aria-label deve contenere sia il testo visibile che la sua spiegazione, ad esempio: `it-aria-label="Visualizza altri 4 utenti"`. In questo modo uno screen reader leggerà l'intera descrizione fornendo il contesto completo all'utente.</p></div></div>
+<p>Usa l'attributo `it-aria-label` sul componente `<it-dropdown>` per fornire una descrizione completa agli screen reader. L'aria-label deve contenere sia il testo visibile che la sua spiegazione, ad esempio: `it-aria-label="Visualizza altri 4 utenti"`. In questo modo uno screen reader leggerà l'intera descrizione fornendo il contesto completo all'utente.</p></div></div>
 
 <Canvas of={AvatarStories.AvatarSovrapposti} />
 ### Avatar sovrapposti - varianti di dimensione

--- a/packages/back-to-top/stories/it-back-to-top.mdx
+++ b/packages/back-to-top/stories/it-back-to-top.mdx
@@ -8,7 +8,7 @@ import * as Stories from './it-back-to-top.stories';
 <description>Pulsante per tornare rapidamente all'inizio di una pagina con contenuti lunghi</description>
 
 ## Cosa fa
-Il componente Back to top (`it-back-to-top`) genera un pulsante scorciatoia che riporta l'utente in cima alla pagina, particolarmente utile quando ci sono contenuti molto lunghi.
+Il componente Back to top (`<it-back-to-top>`) genera un pulsante scorciatoia che riporta l'utente in cima alla pagina, particolarmente utile quando ci sono contenuti molto lunghi.
 
 [Approfondisci come e quando usare il componente Back to Top](https://designers.italia.it/design-system/componenti/back-to-top/)
 

--- a/packages/bottom-nav/stories/it-bottom-nav.mdx
+++ b/packages/bottom-nav/stories/it-bottom-nav.mdx
@@ -24,23 +24,23 @@ Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto
 
 ## Indicazioni generali
 
-Il componente `it-bottom-nav` è il contenitore principale e include uno o più elementi `it-bottom-nav-item`.
+Il componente `<it-bottom-nav>` è il contenitore principale e include uno o più elementi `<it-bottom-nav-item>`.
 
-Il componente `it-bottom-nav-item` è una singola voce di navigazione e va sempre usato come figlio di `it-bottom-nav`.
+Il componente `<it-bottom-nav-item>` è una singola voce di navigazione e va sempre usato come figlio di `<it-bottom-nav>`.
 
-Ogni `it-bottom-nav-item` espone uno **slot default** in cui inserire il link di navigazione:
+Ogni `<it-bottom-nav-item>` espone uno **slot default** in cui inserire il link di navigazione:
 - Inserisci un normale link `<a href="...">` con al suo interno un'icona e uno `<span class="bottom-nav-label">` per il testo
-- La voce attiva si indica aggiungendo l'attributo `active` sull'elemento `it-bottom-nav-item`
+- La voce attiva si indica aggiungendo l'attributo `active` sull'elemento `<it-bottom-nav-item>`
 - Il componente imposta automaticamente `aria-current="page"` sul link della voce attiva
 
-Se utilizzi un framework JavaScript come React, Angular, Svelte o Vue.js, segui le best practice del framework per la gestione della navigazione e dello stato attivo, assicurandoti di applicare l'attributo `active` all'elemento `it-bottom-nav-item` corrispondente alla pagina corrente.
+Se utilizzi un framework JavaScript come React, Angular, Svelte o Vue.js, segui le best practice del framework per la gestione della navigazione e dello stato attivo, assicurandoti di applicare l'attributo `active` all'elemento `<it-bottom-nav-item>` corrispondente alla pagina corrente.
 <div class="callout callout-primary">
   <div class="callout-inner">
     <div class="callout-title">
       <span class="text">Stili</span>
     </div>
     <p>
-      Alcune classi provenienti da Boostrap Italia sono usate all'interno del link (`bottom-nav-label`, `bottom-nav-badge`, `bottom-nav-alert`, `.icon`). Queste classi si trovano nel light DOM e non possono essere raggiunte dal shadow DOM del componente. Se non stai utilizzando il bundle completo, includi il foglio di stile globale nel tuo progetto per applicare questi stili:
+      Alcune classi provenienti da Boostrap Italia sono usate all'interno del link (`.bottom-nav-label`, `.bottom-nav-badge`, `.bottom-nav-alert`, `.icon`). Queste classi si trovano nel light DOM e non possono essere raggiunte dal shadow DOM del componente. Se non stai utilizzando il bundle completo, includi il foglio di stile globale nel tuo progetto per applicare questi stili:
 
 ```scss
 @use '@italia/bottom-nav/styles/globals' as *;

--- a/packages/breadcrumbs/stories/it-breadcrumbs.mdx
+++ b/packages/breadcrumbs/stories/it-breadcrumbs.mdx
@@ -10,7 +10,7 @@ import * as BreadcrumbsStories from './it-breadcrumbs.stories';
 
 ## Cosa fa
 
-Il componente Breadcrumbs (`it-breadcrumbs`) indica la posizione delle pagine all’interno del sito, utile quando i contenuti sono organizzati su più livelli e gli utenti hanno bisogno di spostarsi velocemente tra i vari livelli.
+Il componente Breadcrumbs (`<it-breadcrumbs>`) indica la posizione delle pagine all’interno del sito, utile quando i contenuti sono organizzati su più livelli e gli utenti hanno bisogno di spostarsi velocemente tra i vari livelli.
 
 [Approfondisci quando e come usare il componente Breadcrumbs](https://designers.italia.it/design-system/componenti/breadcrumbs/)
 
@@ -27,10 +27,10 @@ Modifica gli attributi nella tabella per personalizzare in tempo reale l’aspet
 
 ## Indicazioni generali
 
-Il componente `it-breadcrumbs` è il contenitore principale delle breadcrumbs e include uno o più elementi `it-breadcrumb-item`.
-Il componente `it-breadcrumb-item` è un singolo elemento breadcrumb e va sempre usato come figlio di `it-breadcrumbs`.
+Il componente `<it-breadcrumbs>` è il contenitore principale delle breadcrumbs e include uno o più elementi `<it-breadcrumb-item>`.
+Il componente `<it-breadcrumb-item>` è un singolo elemento breadcrumb e va sempre usato come figlio di `<it-breadcrumbs>`.
 
-Il componente `it-breadcrumb-item` espone i seguenti slot:
+Il componente `<it-breadcrumb-item>` espone i seguenti slot:
 - **default**, per ogni singola voce delle breadcrumbs. Inserisci un normale link `<a>`, eventualmente accompagnato da altri elementi inline;
 - **separator**, per l'elemento separatore personalizzato (ad esempio un'icona).
 
@@ -61,7 +61,7 @@ Il componente Breadcrumbs implementa le specifiche ARIA [WAI-ARIA Authoring Prac
       <span class="text">Nota sui test di accessibilità</span>
     </div>
     <p>
-      Axe e altri strumenti di analisi statica possono segnalare falsi positivi quando analizzano il componente `it-breadcrumbs` a causa del limitato supporto per i Web Components. La struttura accessibile effettiva è corretta, come confermato dall'Accessibility Tree e dai test manuali con screen reader.
+      Axe e altri strumenti di analisi statica possono segnalare falsi positivi quando analizzano il componente `<it-breadcrumbs>` a causa del limitato supporto per i Web Components. La struttura accessibile effettiva è corretta, come confermato dall'Accessibility Tree e dai test manuali con screen reader.
     </p>
   </div>
 </div>
@@ -69,15 +69,15 @@ Il componente Breadcrumbs implementa le specifiche ARIA [WAI-ARIA Authoring Prac
 
 ## Con icona
 
-Per aggiungere un'icona a un elemento `it-breadcrumb-item`, inserisci un componente `it-icon` all'interno del tag `<a>`.
+Per aggiungere un'icona a un elemento `<it-breadcrumb-item>`, inserisci un componente `<it-icon>` all'interno del tag `<a>`.
 
 <Canvas of={BreadcrumbsStories.ConIcona} />
 
 ## Separatore personalizzato
 
 Di default, il componente Breadcrumbs usa `/` come separatore tra gli elementi. Puoi personalizzarlo in due modi:
-- utilizzando l'attributo `separator` su `it-breadcrumbs` (ad esempio, `>`);
-- inserendo un elemento personalizzato (come un'icona) nello slot `separator` di ogni `it-breadcrumb-item`.
+- utilizzando l'attributo `separator` su `<it-breadcrumbs>` (ad esempio, `>`);
+- inserendo un elemento personalizzato (come un'icona) nello slot `separator` di ogni `<it-breadcrumb-item>`.
 
 <Canvas of={BreadcrumbsStories.SeparatorePersonalizzato} />
 
@@ -91,7 +91,7 @@ Aggiungi l'attributo `dark` per utilizzare la versione delle breadcrumbs su sfon
       <span class="text">Accessibilità e icone</span>
     </div>
     <p>
-      Quando usi icone negli slot `separator` o come contenuto di un `it-breadcrumb-item` ricorda di impostare manualmente il colore appropriato in modo da garantire un contrasto che rispetti le linee guida di accessibilità.
+      Quando usi icone negli slot `separator` o come contenuto di un `<it-breadcrumb-item>` ricorda di impostare manualmente il colore appropriato in modo da garantire un contrasto che rispetti le linee guida di accessibilità.
     </p>
   </div>
 </div>
@@ -102,9 +102,9 @@ Aggiungi l'attributo `dark` per utilizzare la versione delle breadcrumbs su sfon
 
 Per personalizzare gli stili, puoi usare i selettori `::part` dedicati:
 
-- `::part(breadcrumbs-container)`, per l'elemento `nav` che contiene le breadcrumbs;
-- `::part(breadcrumbs)`, per l'elemento `ol` che contiene le voci;
-- `::part(breadcrumb-item)`, per ogni singolo elemento `li` della lista;
+- `::part(breadcrumbs-container)`, per l'elemento `<nav>` che contiene le breadcrumbs;
+- `::part(breadcrumbs)`, per l'elemento `<ol>` che contiene le voci;
+- `::part(breadcrumb-item)`, per ogni singolo elemento `<li>` della lista;
 - `::part(separator)`, per l'elemento usato come separatore tra le voci.
 
 [Vai alla guida sul selettore part](/docs/personalizzazione-degli-stili--documentazione#selettore-part)

--- a/packages/button/stories/it-button.mdx
+++ b/packages/button/stories/it-button.mdx
@@ -8,7 +8,7 @@ import * as Stories from './it-button.stories';
 <description>Pulsante con etichetta di testo o icona che al clic inizia un'azione o un evento</description>
 
 ## Cosa fa
-Il componente `it-button` ti consente di generare pulsanti la cui interazione dà il via a un’azione o a un evento.
+Il componente `<it-button>` ti consente di generare pulsanti la cui interazione dà il via a un’azione o a un evento.
 Non dovrebbero essere usati per attivare la navigazione verso altre pagine o link esterni.
 
 [Approfondisci come e quando usare il componente Button](https://designers.italia.it/design-system/componenti/buttons/)
@@ -30,7 +30,7 @@ Questo può provocare complesse problematiche di accessibilità.
 - Dove il click sul pulsante non genera un cambio di pagina utilizza esclusivamente il componente `<it-button>`.
 Qualora non fosse possibile, è necessario applicare in modo appropriato l’attributo `role="button"` su elementi `<a>` o `<span>` per trasmetterne lo scopo alle tecnologie assistive.
 
-- Quando si utilizza l'attributo `disabled` è consigliato usare anche l'attributo `it-aria-describedby` (o un elemento all'interno di it-button con classe `.sr-only`) per informare tramite gli screen-reader il motivo per il quale il pulsante è disabilitato.
+- Quando si utilizza l'attributo `disabled` è consigliato usare anche l'attributo `it-aria-describedby` (o un elemento all'interno di `<it-button>` con classe `.sr-only`) per informare tramite gli screen-reader il motivo per il quale il pulsante è disabilitato.
 
 #### Note sugli attributi ARIA
 

--- a/packages/callout/stories/it-callout.mdx
+++ b/packages/callout/stories/it-callout.mdx
@@ -9,7 +9,7 @@ import * as CalloutStories from './it-callout.stories';
 
 ## Cosa fa
 
-Il componente Callout (`it-callout`) è un contenitore che evidenzia parti del testo che richiedono particolare attenzione, come messaggi di errore, avvertimenti e suggerimenti.
+Il componente Callout (`<it-callout>`) è un contenitore che evidenzia parti del testo che richiedono particolare attenzione, come messaggi di errore, avvertimenti e suggerimenti.
 
 [Approfondisci quando e come usare il componente Callout](https://designers.italia.it/design-system/componenti/callout/)
 
@@ -48,7 +48,7 @@ Per garantire una corretta gerarchia dei contenuti, usa l'attributo `heading-lev
 
 Il valore predefinito è `h2`. Assicurati di scegliere il livello corretto per mantenere una struttura gerarchica logica del documento.
 
-Se l'icona comunica un'informazione non presente nel testo (ad esempio, allarme o conferma), usa l'attributo `label` di `it-icon` per fornire una descrizione accessibile agli screen reader. [Approfondisci l'accessibilità delle icone](/docs/componenti-icon--docs#accessibilità)
+Se l'icona comunica un'informazione non presente nel testo (ad esempio, allarme o conferma), usa l'attributo `label` di `<it-icon>` per fornire una descrizione accessibile agli screen reader. [Approfondisci l'accessibilità delle icone](/docs/componenti-icon--docs#accessibilità)
 
 
 
@@ -100,7 +100,7 @@ Usa l'attributo <code>highlight</code> in combinazione con l'attributo <code>var
 
 Il callout **approfondimento** ha uno stile visivo differente ed è indicato per contenuti testuali più estesi, spesso accompagnati da sezioni richiudibili (collapse) e link di download.
 
-- Usa l'attributo <code>callout-more</code> di `it-callout` per applicare lo stile di approfondimento.
+- Usa l'attributo <code>callout-more</code> di `<it-callout>` per applicare lo stile di approfondimento.
 
 - Usa il componente `<it-callout-more>` nello slot `more-content` per aggiungere sezioni richiudibili.
 
@@ -117,13 +117,13 @@ Il callout **approfondimento** ha uno stile visivo differente ed è indicato per
 
 Per personalizzare gli stili, puoi usare questi selettori `::part` dedicati e queste proprietà CSS personalizzabili.
 
-#### Selettori di `it-callout`
+#### Selettori di `<it-callout>`
 
 - `::part(callout)`, per l'elemento contenitore principale del callout;
 - `::part(inner)`, per il contenitore interno del callout;
 - `::part(title)`, per l'elemento titolo del callout.
 
-#### Selettori di `it-callout-more` (approfondimento)
+#### Selettori di `<it-callout-more>` (approfondimento)
 
 - `::part(trigger)`, per il pulsante espandi/collassa;
 - `::part(extra)`, per il contenitore per contenuti extra (ad esempio, un link di download);

--- a/packages/card/stories/it-card.mdx
+++ b/packages/card/stories/it-card.mdx
@@ -9,7 +9,7 @@ import * as Stories from './it-card.stories';
 
 ## Cosa fa
 
-Il componente Card (`it-card`) organizza e presenta contenuti strutturati in modo coerente, offrendo un contenitore flessibile e adattabile a diversi contesti e necessità.
+Il componente Card (`<it-card>`) organizza e presenta contenuti strutturati in modo coerente, offrendo un contenitore flessibile e adattabile a diversi contesti e necessità.
 
 [Approfondisci come e quando usare il componente Card](https://designers.italia.it/design-system/componenti/card/)
 
@@ -53,7 +53,7 @@ Per le **immagini**, usa l'attributo `alt`:
 
 ### Collegamenti e navigazione
 
-- Usa `a` per i collegamenti di navigazione e `button` per azioni nella stessa pagina.
+- Usa `<a>` per i collegamenti di navigazione e `<button>` per azioni nella stessa pagina.
 - Segnala chiaramente la destinazione dei link esterni con testo nascosto e icone appropriate.
 - Usa i titoli come elementi principali di navigazione, evitando troppi collegamenti nella stessa card.
 
@@ -61,7 +61,7 @@ Negli esempi non abbiamo usato il target del link per favorire la normale naviga
 
 ### Date e orari nelle card
 
-- Quando presenti date e orari, usa l'elemento `time` con l'appropriato attributo `datetime`.
+- Quando presenti date e orari, usa l'elemento `<time>` con l'appropriato attributo `datetime`.
 - Inserisci eventuali contenuti guida per lettori di schermo solo se realmente necessari per evitare il rumore, ad esempio `<span class="visually-hidden">Data evento:</span>`.
 - Comunica chiaramente agli utenti quando una data ha il ruolo di "Scadenza" aggiungendo un testo adeguato oltre alla data stessa, come negli esempi che trovi per la variante "Card per servizi e bandi".
 - Non usare solo il colore (negli esempi `.text-warning`) per veicolare l'importanza dell'informazione.
@@ -70,9 +70,9 @@ Negli esempi non abbiamo usato il target del link per favorire la normale naviga
 
 ### Gerarchia dei titoli
 
-Usa il corretto livello di intestazione (`h2`, `h3`, ecc.) per il titolo delle card.
+Usa il corretto livello di intestazione (`<h2>`, `<h3>`, ecc.) per il titolo delle card.
 
-Negli esempi abbiamo usato quasi sempre `h3` per le card editoriali e `h4` per quelle informative, ma ricorda di adattare il codice in base alla gerarchia dei contenuti sulle tue pagine.
+Negli esempi abbiamo usato quasi sempre `<h3>` per le card editoriali e `<h4>` per quelle informative, ma ricorda di adattare il codice in base alla gerarchia dei contenuti sulle tue pagine.
 
 
 ### Contrasto e visibilità
@@ -93,7 +93,7 @@ La struttura dei metadati include:
 
 - categorie nell'elemento `.it-card-taxonomy`;
 - argomenti (tag) in liste, quando sono più di uno;
-- date in elementi HTML semantici `time`, con il corretto attributo `datetime`.
+- date in elementi HTML semantici `<time>`, con il corretto attributo `datetime`.
 
 <Canvas of={Stories.EditorialiStandard} />
 
@@ -134,7 +134,7 @@ Usa questa variante per mostrare contenuti relativi a eventi.
 
 - Per mostrare la data o la durata di un evento, aggiungili in un paragrafo all'inizio del corpo della card usando lo slot `subtitle`.
 - Usa lo slot `actions` per collegamenti o pulsanti secondari, utile quando il titolo porta alla pagina di descrizione dell'evento ma vuoi dare accesso diretto all'azione principale (ad esempio, l'iscrizione all'evento).
-- Per applicare il colore secondario ai collegamenti `a` inseriti nel corpo o nel footer della card, usa la classe `.it-card-link`.
+- Per applicare il colore secondario ai collegamenti `<a>` inseriti nel corpo o nel footer della card, usa la classe `.it-card-link`.
 
 <Canvas of={Stories.Eventi} />
 
@@ -170,7 +170,7 @@ Usa queste varianti per fornire un'anteprima per pagine di dettaglio di servizi 
 - Per fornire indicazioni sullo stato del servizio o del bando, usa un componente [Chip](/docs/componenti-chip--documentazione) nell'elemento `footer`.
 - Per indicare una data di scadenza, usa la classe `.it-card-date` e un testo descrittivo nell'elemento `footer`.
 - Usa lo slot `actions` per collegamenti o pulsanti secondari, utile quando il titolo porta alla pagina di approfondimento ma vuoi dare accesso diretto all'azione principale (ad esempio, la candidatura al bando).
-- Usa la classe `.it-card-link` per applicare il colore secondario ai collegamenti `a` inseriti nel corpo o nel footer della card.
+- Usa la classe `.it-card-link` per applicare il colore secondario ai collegamenti `<a>` inseriti nel corpo o nel footer della card.
 
 <Canvas of={Stories.ServiziEBandi} />
 
@@ -187,7 +187,7 @@ Usa questa variante per rappresentare profili personali o i relatori di un event
 
 - Attivala usando l'attributo `variant="profile"`.
 - Per un'immagine di profilo sulla destra, integra il componente [Avatar](/docs/componenti-avatar--documentazione), idealmente nelle varianti di dimensioni `xl`.
-- La lista di metadati del profilo è costruita utilizzando liste descrittive `.it-card-description-list` con ogni coppia di item `dd`-`dt` raccolta in un `div` contenitore.
+- La lista di metadati del profilo è costruita utilizzando liste descrittive `.it-card-description-list` con ogni coppia di item `<dd>`-`<dt>` raccolta in un `<div>` contenitore.
 - Per un effetto decorativo, usa l'attributo `border-top` e le [varianti di colore disponibili nella tabella degli attributi](#anteprima-e-attributi-del-componente).
 
 <Canvas of={Stories.ProfiliPersonali} />
@@ -198,8 +198,8 @@ Usa questa variante per rappresentare dei luoghi.
 
 - Attivala usando l'attributo `variant="location"`.
 - Per aggiungere un'immagine, usa lo slot `image`.
-- Per aggiungere un'icona sulla destra e allinearla correttamente, racchiudila in un `div` con classe `.it-card-profile-image-icon-wrapper`.
-- La lista di metadati del luogo è costruita utilizzando liste descrittive `.it-card-description-list` con ogni coppia di item `dd`-`dt` raccolta in un `div` contenitore.
+- Per aggiungere un'icona sulla destra e allinearla correttamente, racchiudila in un `<div>` con classe `.it-card-profile-image-icon-wrapper`.
+- La lista di metadati del luogo è costruita utilizzando liste descrittive `.it-card-description-list` con ogni coppia di item `<dd>`-`<dt>` raccolta in un `<div>` contenitore.
 - Per eventuali collegamenti o dettagli della mappa, puoi usare lo slot `footer`.
 
 <Canvas of={Stories.Luoghi} />
@@ -215,7 +215,7 @@ Usa questa variante quando vuoi facilitare l'accesso a contenuti importanti, com
 
 <it-callout variant="success" heading-level="h4">
   <span slot="title">Accessibilità dei link</span>
-  <p>Valuta se applicare un aria-label all'elemento `ul` per permettere ai lettori di schermo di comprendere la natura di questi link.</p>
+  <p>Valuta se applicare un aria-label all'elemento `<ul>` per permettere ai lettori di schermo di comprendere la natura di questi link.</p>
 </it-callout>
 
 
@@ -322,7 +322,7 @@ Per personalizzare gli stili del componente, puoi usare il selettore `::part` co
 
 ### Uso di contenitori responsive
 
-Se il layout lo consente, racchiudi ogni gruppo di card in un contenitore responsive, usando le classi `.container-xl` o `.container-xxl` su un elemento `div` che includa l'intero gruppo e il suo sistema di griglie.
+Se il layout lo consente, racchiudi ogni gruppo di card in un contenitore responsive, usando le classi `.container-xl` o `.container-xxl` su un elemento `<div>` che includa l'intero gruppo e il suo sistema di griglie.
 
 In questo modo sfrutti al meglio lo spazio disponibile su tutte le dimensioni di viewport e livelli di ingrandimento. L’uso di contenitori con breakpoint fissi come `.container` può invece lasciare troppo spazio vuoto ai lati in alcune configurazioni.
 
@@ -384,7 +384,7 @@ Esempio di lista di card:
 
 ### Uso di classi dedicate (per piccoli gruppi)
 
-Per piccoli gruppi di card (2–6 elementi), puoi usare `.it-card-group` per creare facilmente un layout responsive all’interno di un `div` contenitore.
+Per piccoli gruppi di card (2–6 elementi), puoi usare `.it-card-group` per creare facilmente un layout responsive all’interno di un `<div>` contenitore.
 
 Di default, il layout prevede 4 colonne su desktop.
 

--- a/packages/carousel/stories/it-carousel.mdx
+++ b/packages/carousel/stories/it-carousel.mdx
@@ -8,7 +8,7 @@ import * as Stories from './it-carousel.stories';
 <description>Componente di presentazione per scorrere orizzontalmente una sequenza di elementi, immagini o diapositive di testo.</description>
 
 ## Cosa fa
-Il componente Carousel (`it-carousel`) mostra contenuti correlati che non possono essere visualizzati tutti insieme, permettendo di sfogliarli orizzontalmente.
+Il componente Carousel (`<it-carousel>`) mostra contenuti correlati che non possono essere visualizzati tutti insieme, permettendo di sfogliarli orizzontalmente.
 
 È utile per eventi, notizie o servizi in evidenza, ma evita di usarlo per contenuti critici, perché alcuni utenti potrebbero non notarli.
 
@@ -24,12 +24,12 @@ Per comprendere appieno le funzionalità del componente e delle sue varianti, co
 <Controls of={Stories.EsempioInterattivo} />
 
 ## Indicazioni generali
-Il componente `it-carousel` consente di creare una sequenza orizzontale di qualsiasi elemento HTML (card, immagini, video, ecc.).
+Il componente `<it-carousel>` consente di creare una sequenza orizzontale di qualsiasi elemento HTML (card, immagini, video, ecc.).
 
 Per implementarlo correttamente:
 - usa il tag `<it-carousel>` come wrapper principale;
 - inserisci ogni elemento "slide" all'interno di un elemento `<it-carousel-slide>`, nello slot di default;
-- fornisci un'intestazione nello slot `title` usando un elemento `h` (`h2`–`h6`).
+- fornisci un'intestazione nello slot `title` usando un elemento `h` (`<h2>`–`<h6>`).
 
 Il componente espone i seguenti attributi:
 - `variant`, per selezionare la variante di layout;
@@ -40,10 +40,10 @@ Il componente espone i seguenti attributi:
 - `config`, oggetto per personalizzazioni avanzate che estende le opzioni offerte da Splide, passato come stringa JSON nell'attributo.
 
 ## Accessibilità
-Il componente `it-carousel` integra Splide.js e segue le specifiche [W3C Carousel Design Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/). Per tutte le funzionalità di accessibilità offerte dalla libreria, [consulta la documentazione di Splide](https://splidejs.com/guides/accessibility).
+Il componente `<it-carousel>` integra Splide.js e segue le specifiche [W3C Carousel Design Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/). Per tutte le funzionalità di accessibilità offerte dalla libreria, [consulta la documentazione di Splide](https://splidejs.com/guides/accessibility).
 
 - Il wrapper principale usa `role="region"` per permettere agli utenti di lettori di schermo di individuare e saltare rapidamente alla sezione.
-- Puoi assegnare un nome accessibile automaticamente: inserendo un elemento `h` (`h2`-`h6`) nello slot `title`. Il componente genera un ID univoco e lo collega al carousel tramite `aria-labelledby`. Se vuoi nascondere l'intestazione visivamente, puoi utilizzare la classe `visually-hidden` sull'elemento di intestazione.
+- Puoi assegnare un nome accessibile automaticamente: inserendo un elemento `h` (`<h2>`-`<h6>`) nello slot `title`. Il componente genera un ID univoco e lo collega al carousel tramite `aria-labelledby`. Se vuoi nascondere l'intestazione visivamente, puoi utilizzare la classe `.visually-hidden` sull'elemento di intestazione.
 - Tutti le slide non visibili hanno l'attributo `inert`, così gli utenti che navigano con la tastiera non finiscono su elementi nascosti.
 - I controlli (frecce e paginazione) sono realizzati con elementi `<button>` nativi. Durante la transizione, il componente rimuove preventivamente le restrizioni di focus dalla slide di destinazione per permettere alle tecnologie assistive di seguirne il contenuto.
 - Con autoplay attivo, viene fornito un pulsante Play/Pausa. Per impostazione predefinita, il carousel è in modalità pausa: movimento e animazioni sono disabilitati durante hover, focus o se l'utente ha scelto di ridurre le animazioni nelle impostazioni del sistema operativo o del browser.
@@ -56,7 +56,7 @@ Per garantire un'esperienza utente ottimale ed accessibile:
 - assicurati che il carousel non interferisca con altri elementi interattivi sulla pagina;
 - imposta una velocità di transizione adeguata per permettere alle persone di assimilare le informazioni;
 - verifica che le immagini o i contenuti siano di alta qualità, chiaramente visibili su tutti i dispositivi e che includano testo alternativo descrittivo;
-- fornisci sempre un'intestazione chiara e descrittiva dello scopo e dei contenuti del carousel. Se l'intestazione è puramente decorativa, nascondila visivamente usando la classe `visually-hidden`.
+- fornisci sempre un'intestazione chiara e descrittiva dello scopo e dei contenuti del carousel. Se l'intestazione è puramente decorativa, nascondila visivamente usando la classe `.visually-hidden`.
 
 ### Live region (`aria-live`) e comportamento con gli screen reader
 
@@ -254,7 +254,7 @@ Il componente espone i seguenti metodi e eventi accessibili via JavaScript.
 
 
 ## Personalizzazione degli stili
-Per personalizzare l'aspetto di `it-carousel` dall'esterno dello shadow DOM, usa il selettore `::part()` sui seguenti part esposti dal componente:
+Per personalizzare l'aspetto di `<it-carousel>` dall'esterno dello shadow DOM, usa il selettore `::part()` sui seguenti part esposti dal componente:
 
 - `arrows`, per il wrapper che contiene i pulsanti freccia (prev/next);
 - `arrow-prev`, per il pulsante "precedente";

--- a/packages/checkbox/stories/it-checkbox.mdx
+++ b/packages/checkbox/stories/it-checkbox.mdx
@@ -8,7 +8,7 @@ import * as Stories from './it-checkbox.stories';
 <description>Casella di controllo che consente di selezionare una o più opzioni da un elenco predefinito.</description>
 
 ## Cosa fa
-Il componente Checkbox (`it-checkbox`) permette all’utente di selezionare o deselezionare una o più opzioni in modo indipendente, utile quando sono consentite scelte multiple.
+Il componente Checkbox (`<it-checkbox>`) permette all’utente di selezionare o deselezionare una o più opzioni in modo indipendente, utile quando sono consentite scelte multiple.
 
 [Approfondisci come e quando usare il componente Checkbox](https://designers.italia.it/design-system/componenti/checkbox/)
 
@@ -43,7 +43,7 @@ Questi attributi sono:
 
 Inserisci l'etichetta del gruppo in un elemento con attributo `slot="legend"` all'interno di `<it-checkbox-group>`.
 
-Quando utilizzi il componente `it-checkbox-group` in un form, il modo corretto per estrarre il valore del campo al submit via JS è:
+Quando utilizzi il componente `<it-checkbox-group>` in un form, il modo corretto per estrarre il valore del campo al submit via JS è:
 
 ```js
 const formData = new FormData(document.getElementById('form'));

--- a/packages/chip/stories/it-chip.mdx
+++ b/packages/chip/stories/it-chip.mdx
@@ -27,7 +27,7 @@ Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto
 
 ## Informazioni generali
 
-Il componente `it-chip` si compone principalmente di una label testuale e, opzionalmente, di:
+Il componente `<it-chip>` si compone principalmente di una label testuale e, opzionalmente, di:
 
 - un **avatar** (immagine) a sinistra, tramite la proprietà `avatar`
 - un'**icona** inserita nello slot `icon`
@@ -86,7 +86,7 @@ L'avatar viene ridimensionato automaticamente in base alla dimensione della chip
 ## Chip con icona
 
 
-Le chip possono includere un'icona utilizzando lo slot `icon` con il componente `it-icon`.
+Le chip possono includere un'icona utilizzando lo slot `icon` con il componente `<it-icon>`.
 
 L'icona viene ridimensionata automaticamente:
 - Chip `sm` imposta la dimensione dell'icona a `xs`
@@ -132,7 +132,7 @@ Il componente espone i seguenti metodi e eventi accessibili via JavaScript.
 - `close()` — rimuove la chip dal DOM, spostando il focus su una chip adiacente se presente.
 
 ### Eventi
-- `it-chip-close` — emesso al click sul pulsante di rimozione. L'evento è cancellabile: chiamando `event.preventDefault()` si impedisce la rimozione automatica. Il `detail` contiene `chip`, riferimento all'elemento `it-chip` corrente.
+- `it-chip-close` — emesso al click sul pulsante di rimozione. L'evento è cancellabile: chiamando `event.preventDefault()` si impedisce la rimozione automatica. Il `detail` contiene `chip`, riferimento all'elemento `<it-chip>` corrente.
 
 ## Chip disabilitata
 
@@ -144,7 +144,7 @@ Usa l'attributo `is-disabled` per disabilitare una chip. La chip disabilitata no
 
 Per la personalizzazione degli stili puoi usare i selettori `::part` dedicati:
 
-- `::part(chip)` - elemento chip (div o a, a seconda della presenza di `href`)
+- `::part(chip)` - elemento chip (`<div>` o `<a>`, a seconda della presenza di `href`)
 - `::part(focusable)` - presente solo quando la chip è un link (`href` valorizzato)
 
 [Vai alla guida sul selettore part](/docs/personalizzazione-degli-stili--documentazione#selettore-part)

--- a/packages/collapse/stories/it-collapse.mdx
+++ b/packages/collapse/stories/it-collapse.mdx
@@ -9,7 +9,7 @@ import * as CollapseStories from './it-collapse.stories';
 
 ## Cosa fa
 
-Il componente Collapse (`it-collapse`) è un elemento richiudibile che ottimizza l’ingombro dei contenuti di una pagina.
+Il componente Collapse (`<it-collapse>`) è un elemento richiudibile che ottimizza l’ingombro dei contenuti di una pagina.
 
 Su questo componente si basa anche il [componente Accordion](?path=/docs/componenti-accordion--documentazione), usando i collapse in gruppo e permettendo di attivarli indipendentemente l’uno dall’altro oppure in modo esclusivo con l’attivazione di solo un blocco alla volta.
 
@@ -30,7 +30,7 @@ Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto
 
 ## Indicazioni generali
 
-Il componente `it-collapse` utilizza diversi slot per definire il trigger, il testo mostrato nel trigger e il contenuto richiudibile:
+Il componente `<it-collapse>` utilizza diversi slot per definire il trigger, il testo mostrato nel trigger e il contenuto richiudibile:
 
 - `slot="trigger"`, per inserire un elemento personalizzato da utilizzare come trigger per aprire/chiudere il collapse (**opzionale**);
 - `slot="label"`, per inserire il testo da mostrare nel trigger di default (**obbligatorio**, anche nel caso di [trigger personalizzato](#trigger-personalizzato));

--- a/packages/dev-kit-italia/stories/Accessibilita.mdx
+++ b/packages/dev-kit-italia/stories/Accessibilita.mdx
@@ -196,7 +196,7 @@ Nella configurazione attuale produce quindi un numero elevato di falsi positivi,
 
 `list` e `listitem` segnalati su `<it-breadcrumbs>`. L'accessibility tree è corretto. Falso positivo documentato nella storia del componente al [paragrafo Accessibilità](/?path=/docs/componenti-breadcrumbs--documentazione#accessibilità).
 
-### `it-carousel`: live region (`aria-live`) e comportamento nei screen reader
+### `<it-carousel>`: live region (`aria-live`) e comportamento nei screen reader
 
 Il supporto all'`aria-live` region è incostante tra combinazioni di screen reader, sistemi operativi e browser (es. VoiceOver + Chrome/Firefox su macOS non funziona). Non costituisce una violazione WCAG: l'attributo è opzionale per la specifica W3C e il feedback primario è garantito dal pattern `role="tablist"` del componente. Dettagli e tabella di compatibilità nella storia del componente al [paragrafo Accessibilità](/?path=/docs/componenti-carousel--documentazione#accessibilità).
 

--- a/packages/dev-kit-italia/stories/Internazionalizzazione.mdx
+++ b/packages/dev-kit-italia/stories/Internazionalizzazione.mdx
@@ -10,7 +10,7 @@ Se vi è necessità di avere traduzioni in altre lingue, è compito dello svilup
 
 ## Cambio di lingua
 
-Per cambiare la lingua corrente a livello di sito, è sufficiente modificare l'attributo `lang` sull'elemento `html`. Le modifiche a `<html lang>` attivano automaticamente l’aggiornamento di tutti i componenti localizzati:
+Per cambiare la lingua corrente a livello di sito, è sufficiente modificare l'attributo `lang` sull'elemento `<html>`. Le modifiche a `<html lang>` attivano automaticamente l’aggiornamento di tutti i componenti localizzati:
 
 ```html
 <html lang="en">

--- a/packages/dev-kit-italia/stories/components/form.mdx
+++ b/packages/dev-kit-italia/stories/components/form.mdx
@@ -25,7 +25,7 @@ Strutture più complesse possono essere costruite usando il sistema a griglia, d
 La classe `.row` ne assicura una corretta spaziatura. Questa classe deve essere applicata ad un elemento html contenitore (ad esempio un `<div>`).
 
 Si può scegliere di dare una dimensione ad una colonna, ad esempio dandogli una classe `.col-md-6` per ottenere una certo design dal breakpoint `md` in su, mentre le restanti colonne con classe `.col-md` si divideranno il resto dello spazio.
-La classe `.col-md*` può essere applicata sia ad un tag html che fa da contenitore (ad esempio un `div`), sia al componente di input stesso (ad esempio su `<it-input class="col-md-6">`).
+La classe `.col-md*` può essere applicata sia ad un tag html che fa da contenitore (ad esempio un `<div>`), sia al componente di input stesso (ad esempio su `<it-input class="col-md-6">`).
 
 <Canvas of={Stories.DimensionamentoColonne} />
 
@@ -34,7 +34,7 @@ La classe `.col-md*` può essere applicata sia ad un tag html che fa da contenit
 L’esempio seguente usa una delle [utilità di flexbox](https://italia.github.io/bootstrap-italia/docs/organizzare-gli-spazi/flex/) per centrare verticalmente dal breakpoint `lg` in su il contenuto e cambiando `.col` con `.col-auto` in modo che le colonne occupino solo lo spazio necessario.
 In altre parole, la colonna si dimensiona in base al contenuto.
 
-È possibile usarlo anche quando sono presenti altre colonne con dimensioni specifiche (es.: `col-sm-3`).
+È possibile usarlo anche quando sono presenti altre colonne con dimensioni specifiche (es.: `.col-sm-3`).
 
 <Canvas of={Stories.Autodimensionamento} />
 

--- a/packages/dev-kit-italia/stories/components/it-list.mdx
+++ b/packages/dev-kit-italia/stories/components/it-list.mdx
@@ -28,7 +28,7 @@ Le liste, costituite da tag `<ul>` con classe `.it-list` all'interno di un wrapp
 
 ### Lista con avatar
 
-Per aggiungere un avatar, inserisci l'elemento `it-avatar` prima dell'elemento `.it-right-zone` che contiene il testo.
+Per aggiungere un avatar, inserisci l'elemento `<it-avatar>` prima dell'elemento `.it-right-zone` che contiene il testo.
 
 <Canvas of={ListStories.ListaConAvatar} />
 
@@ -52,7 +52,7 @@ Le liste con azioni presentano icone o elementi interattivi associati all'azione
 
 ### Con freccia
 
-Per aggiungere una freccia, inserisci l'elemento `it-icon` dopo l'elemento `.text` che contiene il testo.
+Per aggiungere una freccia, inserisci l'elemento `<it-icon>` dopo l'elemento `.text` che contiene il testo.
 
 <Canvas of={ListStories.ListaConFreccia} />
 
@@ -119,8 +119,8 @@ Puoi aggiungere un'icona (a destra o sinistra del testo) e un abstract per ogni 
 
 Per includere un'icona, aggiungi al tag `<a>` una delle seguenti classi:
 
-- `icon-right`, per posizionare l'icona a destra del testo;
-- `icon-left`, per posizionare l'icona a sinistra del testo.
+- `.icon-right`, per posizionare l'icona a destra del testo;
+- `.icon-left`, per posizionare l'icona a sinistra del testo.
 
 Puoi inserire [l'icona necessaria](/docs/componenti-icon--documentazione) all'interno del tag `<span class="list-item-title-icon-wrapper">`, subito dopo o prima dello `<span class="list-item-title">` contenente il testo.
 

--- a/packages/dev-kit-italia/stories/components/it-sidebar.mdx
+++ b/packages/dev-kit-italia/stories/components/it-sidebar.mdx
@@ -35,7 +35,7 @@ Per garantire un'esperienza accessibile, assicurati di:
 - indicare sempre **visivamente** la pagina corrente, usando la classe `.active` sul link corrispondente;
 - indicare sempre **alle tecnologie assistive** la pagina corrente, usando l'attributo `aria-current="page"` sul link corrispondente;
 - segnalare i link disabilitati alle tecnologie assistive, usando l'attributo `aria-disabled="true"`;
-- usare il componente `it-collapse` per le liste collassabili, che gestisce automaticamente gli attributi ARIA necessari (`aria-expanded`, `aria-controls`, `role`);
+- usare il componente `<it-collapse>` per le liste collassabili, che gestisce automaticamente gli attributi ARIA necessari (`aria-expanded`, `aria-controls`, `role`);
 - disabilitare via JavaScript la navigazione dei link/collapse disabilitati per evitare comportamenti inattesi: le diverse varianti forniscono un'implementazione di esempio.
 
 
@@ -61,9 +61,9 @@ Per creare una sidebar con linea separatrice a sinistra, aggiungi la classe `.it
 
 Una sidebar può contenere una lista di link primaria annidata, tramite la classe `.link-sublist` per le sotto-liste espanse.
 
-Per rendere collassabili le sottosezioni della sidebar, usa il componente `it-collapse` integrato nelle liste di navigazione. Il componente `it-collapse` permette di espandere e comprimere le sottosezioni in modo interattivo, migliorando l'esperienza di navigazione su sidebar con molte voci.
+Per rendere collassabili le sottosezioni della sidebar, usa il componente `<it-collapse>` integrato nelle liste di navigazione. Il componente `<it-collapse>` permette di espandere e comprimere le sottosezioni in modo interattivo, migliorando l'esperienza di navigazione su sidebar con molte voci.
 
-Consulta la [documentazione del componente Collapse](/docs/componenti-collapse--documentazione) per maggiori dettagli sull'uso di `it-collapse`.
+Consulta la [documentazione del componente Collapse](/docs/componenti-collapse--documentazione) per maggiori dettagli sull'uso di `<it-collapse>`.
 
 <Canvas of={SidebarStories.SidebarAnnidata} />
 

--- a/packages/dev-kit-italia/stories/components/table.mdx
+++ b/packages/dev-kit-italia/stories/components/table.mdx
@@ -141,7 +141,7 @@ Per evidenziare una riga o una cella, aggiungi la classe `.table-active` al tag 
 Per avere i bordi su tutti i lati della tabella e su tutte le celle, aggiungi la classe `.table-bordered` a `<table>`.
 <Canvas of={TableStories.TabellaBordata} />
 
-Per colorare i bordi, usa la classe `border-{color}` in combinazione con `.table-bordered`. Sostituisci `{color}` con uno dei colori disponibili: `primary`, `secondary`, `success`, `danger`, `warning`, `info`, `light` o `dark`.
+Per colorare i bordi, usa la classe `.border-{color}` in combinazione con `.table-bordered`. Sostituisci `{color}` con uno dei colori disponibili: `primary`, `secondary`, `success`, `danger`, `warning`, `info`, `light` o `dark`.
 
 <Canvas of={TableStories.TabellaBordataPrimary} />
 
@@ -151,7 +151,7 @@ Per una tabella senza bordi, aggiungi la classe `.table-borderless` a `<table>`.
 
 <Canvas of={TableStories.TabellaSenzaBordi} />
 
-Per colorare lo sfondo, usa la classe `table-{color}` in combinazione con `.table-borderless`.
+Per colorare lo sfondo, usa la classe `.table-{color}` in combinazione con `.table-borderless`.
 
 <Canvas of={TableStories.TabellaSenzaBordiDark} />
 
@@ -165,7 +165,7 @@ Per dimezzare il cell padding e rendere le tabelle più compatte, aggiungi la cl
 
 Le celle in `<thead>` sono sempre allineate verticalmente in basso (bottom). Le celle in `<tbody>` ereditano l'allineamento da `<table>` e sono allineate verticalmente in alto (top).
 
-Per modificare l'allineamento, usa le le classi di allineamento verticale `align-{position}`.
+Per modificare l'allineamento, usa le le classi di allineamento verticale `.align-{position}`.
 
 <Canvas of={TableStories.AllineamentoVerticale} />
 

--- a/packages/dev-kit-italia/stories/organizzare-gli-spazi/clearfix.mdx
+++ b/packages/dev-kit-italia/stories/organizzare-gli-spazi/clearfix.mdx
@@ -11,7 +11,7 @@ Annulla il `float` del contenuto aggiungendo la classe `.clearfix` **all'element
 <div class="clearfix">...</div>
 ```
 
-Esempio di visualizzazione senza l'utilizzo della classe `.clearfix`. In questo caso il `div` contenitore non si estende attorno ai pulsanti mostrando un layout incompleto.
+Esempio di visualizzazione senza l'utilizzo della classe `.clearfix`. In questo caso il `<div>` contenitore non si estende attorno ai pulsanti mostrando un layout incompleto.
 
 <Canvas of={Stories.SenzaClearfix} />
 

--- a/packages/dev-kit-italia/stories/organizzare-gli-spazi/dimensionamento.mdx
+++ b/packages/dev-kit-italia/stories/organizzare-gli-spazi/dimensionamento.mdx
@@ -18,7 +18,7 @@ Le altezze di default presenti sono: `25%`, `50%`, `75%` e `100%`.
 
 ## Larghezza massima
 
-Sono previste anche le classi `mw-100` e `mh-100` per i corrispettivi `max-width: 100%;` e `max-height: 100%;`.
+Sono previste anche le classi `.mw-100` e `.mh-100` per i corrispettivi `max-width: 100%;` e `max-height: 100%;`.
 
 <Canvas of={Stories.LarghezzaMassima} />
 

--- a/packages/dev-kit-italia/stories/organizzare-gli-spazi/griglie.mdx
+++ b/packages/dev-kit-italia/stories/organizzare-gli-spazi/griglie.mdx
@@ -140,7 +140,7 @@ La disposizione automatica per le colonne della griglia di flexbox significa anc
 
 ### Contenuto a larghezza variabile
 
-Puoi usare la classe `col-{breakpoint}-auto` per ridimensionare le colonne in base alla naturale larghezza del loro contenuto.
+Puoi usare la classe `.col-{breakpoint}-auto` per ridimensionare le colonne in base alla naturale larghezza del loro contenuto.
 
 <Canvas of={Stories.ContenutoALarghezzaVariabile} />
 

--- a/packages/dev-kit-italia/stories/organizzare-gli-spazi/introduzione.mdx
+++ b/packages/dev-kit-italia/stories/organizzare-gli-spazi/introduzione.mdx
@@ -193,8 +193,8 @@ $zindex-tooltip: 1070 !default;
 ```
 
 Per gestire i bordi sovrapposti all'interno dei componenti (es.: pulsanti e input nei gruppi di input) occorre utilizzare i valori
-di `z-index` a una sola cifra di `1`,` 2` e `3` per default, hover e stati attivi. Al passaggio del mouse/focus/active
-portiamo un particolare elemento in primo piano con un valore più alto di 'z-index` per mostrare il loro confine sugli
+di `z-index` a una sola cifra di `1`, `2` e `3` per default, hover e stati attivi. Al passaggio del mouse/focus/active
+portiamo un particolare elemento in primo piano con un valore più alto di `z-index` per mostrare il loro confine sugli
 elementi di pari livello.
 
 ---

--- a/packages/dev-kit-italia/stories/organizzare-gli-spazi/posizionamento.mdx
+++ b/packages/dev-kit-italia/stories/organizzare-gli-spazi/posizionamento.mdx
@@ -18,7 +18,7 @@ Classi per il posizionamento, non sono presenti varianti per la gestione respons
 
 ## Posizione fissa in alto
 
-Posiziona un elemento in alto nel viewport. Attraverso l'utilizzo di ogni classe `fixed-*` l'elemento assumerà una posizione
+Posiziona un elemento in alto nel viewport. Attraverso l'utilizzo di ogni classe `.fixed-*` l'elemento assumerà una posizione
 _fixed_, ancorandosi al viewport (cioè la finestra del browser) ed uscendo quindi dal normale flusso di posizionamento
 del documento.
 Assicurati di comprendere appieno le implicazioni della [posizione `fixed`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed)

--- a/packages/dev-kit-italia/stories/organizzare-gli-spazi/proporzioni.mdx
+++ b/packages/dev-kit-italia/stories/organizzare-gli-spazi/proporzioni.mdx
@@ -15,8 +15,8 @@ Le proporzioni predefinite sono dichiarate in una mappa Sass ed incluse in ogni 
 >
 > Le seguenti classi utilizzate negli esempi servono unicamente per gli stessi e vanno ignorate:
 >
-> - `ratio-example`
-> - `ratio-example-breakpoint`
+> - `.ratio-example`
+> - `.ratio-example-breakpoint`
 
 **Pro-Tip!** Non hai bisogno di includere l'attributo `frameborder="0"` nei tuoi `<iframe>`, questo viene automaticamente
 sovrascritto.
@@ -24,7 +24,7 @@ sovrascritto.
 ## Esempio
 
 Estendi ogni oggetto, ad esempio un `<iframe>`, aggiungendo al suo contenitore la classe `.ratio` e le proporzioni
-richieste. L'elemento contenuto viene automaticamente ridimensionato grazie al selettore universale `ratio > *`.
+richieste. L'elemento contenuto viene automaticamente ridimensionato grazie al selettore universale `.ratio > *`.
 
 <Canvas of={Stories.EsempioProporzione16x9} />
 

--- a/packages/dev-kit-italia/stories/organizzare-i-contenuti/testo.mdx
+++ b/packages/dev-kit-italia/stories/organizzare-i-contenuti/testo.mdx
@@ -33,7 +33,7 @@ Trasforma il testo con una delle classi per la scrittura in maiuscolo.
 
 <Canvas of={Stories.Trasformazioni} />
 
-Nota come la classe `text-capitalize` cambi solamente la prima lettera di ogni parola lasciando le altre inalterate.
+Nota come la classe `.text-capitalize` cambi solamente la prima lettera di ogni parola lasciando le altre inalterate.
 
 ## Carattere grassetto e corsivo
 

--- a/packages/dev-kit-italia/stories/organizzare-i-contenuti/tipografia.mdx
+++ b/packages/dev-kit-italia/stories/organizzare-i-contenuti/tipografia.mdx
@@ -82,32 +82,32 @@ Queste le dimensioni nel dettaglio (dimensione del testo, peso del font e interl
   </thead>
   <tbody>
     <tr>
-      <td><code>h1</code></td>
+      <td><code>{'<h1>'}</code></td>
       <td>40px (2.5rem); font-weight: 700; line-height: 1.2</td>
       <td>48px (3rem); font-weight: 700; line-height: 1.2</td>
     </tr>
     <tr>
-      <td><code>h2</code></td>
+      <td><code>{'<h2>'}</code></td>
       <td>32px (2rem); font-weight: 700; line-height: 1.2</td>
       <td>40px (2.5rem); font-weight: 700; line-height: 1.2</td>
     </tr>
     <tr>
-      <td><code>h3</code></td>
+      <td><code>{'<h3>'}</code></td>
       <td>28px (1.75rem); font-weight: 700; line-height: 1.2</td>
       <td>32px (2rem); font-weight: 700; line-height: 1.2</td>
     </tr>
     <tr>
-      <td><code>h4</code></td>
+      <td><code>{'<h4>'}</code></td>
       <td>24px (1.5rem); font-weight: 600; line-height: 1.2</td>
       <td>28px (1.75rem); font-weight: 600; line-height: 1.2</td>
     </tr>
     <tr>
-      <td><code>h5</code></td>
+      <td><code>{'<h5>'}</code></td>
       <td>20px (1.25rem); font-weight: 600; line-height: 1.2</td>
       <td>24px (1.5rem); font-weight: 600; line-height: 1.2</td>
     </tr>
     <tr>
-      <td><code>h6</code></td>
+      <td><code>{'<h6>'}</code></td>
       <td>16px (1rem); font-weight: 600; line-height: 1.2</td>
       <td>18px (1.125rem); font-weight: 600; line-height: 1.2</td>
     </tr>
@@ -255,7 +255,7 @@ con un `ellipsis`.
 
 ## Breaking change
 
-- Reimpostata la dimensione del carattere di base su `16px` su `body`.
+- Reimpostata la dimensione del carattere di base su `16px` su `<body>`.
 - Sostituite le unità `em` con `rem`.
 - Aggiornati i valori `font-size` per corrispondere al nuovo calcolo dell'unità `rem`.
 - Rimosse le variabili obsolete e inutilizzate da `_variables.scss`.

--- a/packages/dimmer/stories/it-dimmer.mdx
+++ b/packages/dimmer/stories/it-dimmer.mdx
@@ -79,7 +79,7 @@ Puoi utilizzare l'attributo `variant` con valore `"dark"` per ottenere una versi
 
 ## Dimmer con Azioni
 
-Un dimmer può contenere titoli e pulsanti d'azione. Inseriscili nello slot `content` all'interno di un contenitore con classi `dimmer-buttons bg-dark`. Gli esempi seguenti mostrano le possibili combinazioni di varianti e pulsanti azione.
+Un dimmer può contenere titoli e pulsanti d'azione. Inseriscili nello slot `content` all'interno di un contenitore con classi `.dimmer-buttons` e `.bg-dark`. Gli esempi seguenti mostrano le possibili combinazioni di varianti e pulsanti azione.
 
 <Canvas of={Stories.ConAzioniPrimario} />
 

--- a/packages/dropdown/stories/it-dropdown.mdx
+++ b/packages/dropdown/stories/it-dropdown.mdx
@@ -39,7 +39,7 @@ Puoi specificare una variante tramite l'attributo `variant`, questa verrà appli
 
 ## Accessibilità
 
-Per impostazione predefinita, il componente `it-dropdown` usa la semantica di una semplice lista HTML (`<ul>`/`<li>`), senza ruoli ARIA aggiuntivi. Questa è la scelta corretta nella maggior parte dei casi, in particolare quando il menu contiene link di navigazione o si trova all'interno di un elemento `<nav>` (ad es. header, megamenu).
+Per impostazione predefinita, il componente `<it-dropdown>` usa la semantica di una semplice lista HTML (`<ul>`/`<li>`), senza ruoli ARIA aggiuntivi. Questa è la scelta corretta nella maggior parte dei casi, in particolare quando il menu contiene link di navigazione o si trova all'interno di un elemento `<nav>` (ad es. header, megamenu).
 
 Lo standard [WAI ARIA](https://www.w3.org/TR/wai-aria/) definisce il [`role="menu"`](https://www.w3.org/TR/wai-aria/#menu) per i **menu applicativi**, ovvero menu che espongono comandi o azioni (come "Copia", "Taglia", "Incolla") in modo analogo ai menu di un'applicazione desktop. Puoi usarlo impostando l'attributo `it-role="menu"`, che assegna automaticamente il ruolo corretto anche agli elementi interni.
 
@@ -48,7 +48,7 @@ Lo standard [WAI ARIA](https://www.w3.org/TR/wai-aria/) definisce il [`role="men
   <p>`role="menu"` non è adatto a menu di navigazione o a menu che contengono link a pagine. Non usarlo all'interno di un elemento `<nav>`.</p>
 </it-callout>
 
-Questo componente comprende di base il supporto per la maggior parte delle interazioni standard del menu della tastiera, come la possibilità di spostarsi tra i singoli elementi `it-dropdown-item` usando i tasti freccia, e chiude il menu con il tasto ESC.
+Questo componente comprende di base il supporto per la maggior parte delle interazioni standard del menu della tastiera, come la possibilità di spostarsi tra i singoli elementi `<it-dropdown-item>` usando i tasti freccia, e chiude il menu con il tasto ESC.
 
 Dovrai inserire un'etichetta per il pulsante di attivazione del menu tramite l'attributo `label`, che verrà letta dagli screen reader.
 In alternativa, puoi omettere l'attributo `label` e aggiungere un attributo `it-aria-label` al componente `<it-dropdown>`.

--- a/packages/header/stories/header.mdx
+++ b/packages/header/stories/header.mdx
@@ -46,7 +46,7 @@ Questa soluzione sarà anche utile a dare focus direttamente al tag `<h1>` laddo
 ## Slim Header
 Lo Slim Header mostra un'intestazione, solitamente con riferimento all'ente di appartenenza del progetto o riferimenti utili, oltre ad un eventuale menu per il cambio lingua e l'accesso ad area riservata.
 
-Il cambio lingua è gestito con il componente `it-dropdown`.
+Il cambio lingua è gestito con il componente `<it-dropdown>`.
 
 <Canvas of={HeaderStories.SlimHeader} />
 
@@ -64,7 +64,7 @@ Per applicargli l'aspetto *full-responsive*, a seconda dei due casi puoi:
   <span class="d-none d-lg-block">Accedi all'area personale</span>
 </a>
 ```
-- se è un componente di tipo `it-button` aggiungere l'attributo `full`:
+- se è un componente di tipo `<it-button>` aggiungere l'attributo `full`:
 ```html
 <it-button variant="primary" full>
   <span class="rounded-icon">
@@ -76,7 +76,7 @@ Per applicargli l'aspetto *full-responsive*, a seconda dei due casi puoi:
 <Canvas of={HeaderStories.SlimHeaderActionFull} />
 
 ### Versione chiara
-Per cambiare tema all’Header Slim è sufficiente aggiungere la classe `theme-light` al tag`<div class="it-header-slim-wrapper">`.
+Per cambiare tema all’Header Slim è sufficiente aggiungere la classe `.theme-light` al tag`<div class="it-header-slim-wrapper">`.
 
 <Canvas of={HeaderStories.SlimHeaderLight} />
 
@@ -86,12 +86,12 @@ L'Header Centrale mostra il logo dell’ente e la sua descrizione, i link aggiun
 <Canvas of={HeaderStories.HeaderCenter} />
 
 ### Versione compatta
-Per utilizzare la versione più compatta in altezza dell’header centrale, puoi aggiungere la classe `it-small-header` al tag `<div class="it-header-center-wrapper">`.
+Per utilizzare la versione più compatta in altezza dell’header centrale, puoi aggiungere la classe `.it-small-header` al tag `<div class="it-header-center-wrapper">`.
 
 <Canvas of={HeaderStories.HeaderCenterCompact} />
 
 ### Versione chiara
-Per cambiare tema all’header centrale puoi aggiungere la classe `theme-light` al tag `<div class="it-header-center-wrapper">`.
+Per cambiare tema all’header centrale puoi aggiungere la classe `.theme-light` al tag `<div class="it-header-center-wrapper">`.
 
 <Canvas of={HeaderStories.HeaderCenterLight} />
 
@@ -108,7 +108,7 @@ I’Header Nav ha due temi colore:
 
 Su **mobile** lo stile del menu è sempre uguale, indifferentemente dal tema scelto: ha un **background bianco e testi e link di colore primario**.
 
-Per modificare il tema dell’Header Nav e impostarlo alla versione chiara, è sufficiente aggiungere la classe `theme-light` al tag `<nav class="it-header-navbar-wrapper">`:
+Per modificare il tema dell’Header Nav e impostarlo alla versione chiara, è sufficiente aggiungere la classe `.theme-light` al tag `<nav class="it-header-navbar-wrapper">`:
 
 ```html
 <nav class="it-header-navbar-wrapper theme-light">...</nav>
@@ -180,7 +180,7 @@ Durante la transizione, il componente clona e inserisce nella modale i seguenti 
 - `.it-header-navbar-wrapper nav` che comprende:
     - menu principale
     - menu secondario (se presente), a cui viene aggiunta la classe `.secondary`
-- la lista di collegamenti presente in  `.it-header-slim-wrapper ul`, a cui vengono aggiunte le classi `secondary` e `header-slim-menu`.
+- la lista di collegamenti presente in  `.it-header-slim-wrapper ul`, a cui vengono aggiunte le classi `.secondary` e `.header-slim-menu`.
 - il blocco social `.it-socials`
 
 Nel menu mobile quindi gli elementi sono ordinati in questo modo:
@@ -197,10 +197,10 @@ Quando la viewport supera la dimensione prevista dall'attributo `breakpoint`, la
 ## Header Sticky
 Per rendere sticky l'header durante lo scroll della pagina, wrappa l'intera struttura con il componente `<it-sticky>`.
 
-In questo caso la classe `.it-header-wrapper` (e `it-header-sticky`) va spostata su `<it-sticky>` — e **non** sul tag `<header>` interno:
+In questo caso la classe `.it-header-wrapper` (e `.it-header-sticky`) va spostata su `<it-sticky>` — e **non** sul tag `<header>` interno:
 
 Ricordati di:
-- aggiungere l'attributo `sticky-class-name="is-sticky"` per applicare la classe `is-sticky` quando l'header diventa sticky, in modo da poter gestire eventuali stili specifici per questo stato.
+- aggiungere l'attributo `sticky-class-name="is-sticky"` per applicare la classe `.is-sticky` quando l'header diventa sticky, in modo da poter gestire eventuali stili specifici per questo stato.
 - aggiungere l'attributo `trigger-selector` con l'`id` dell'`<it-header>` interno, in modo che lo sticky si attivi solo dopo che l'intero header ha superato il bordo superiore della viewport (e non immediatamente al primo pixel di scroll).
 
 Esempio:
@@ -217,5 +217,5 @@ Esempio:
 
 [Vai all'esempio per questa funzionalità](?path=/story/esempi-header--header-sticky)
 
-Per maggiori dettagli su come utilizzare il componente `it-sticky` e le sue funzionalità, consulta la [documentazione dedicata](?path=/docs/componenti-sticky--documentazione).
+Per maggiori dettagli su come utilizzare il componente `<it-sticky>` e le sue funzionalità, consulta la [documentazione dedicata](?path=/docs/componenti-sticky--documentazione).
 

--- a/packages/hero/stories/it-hero.mdx
+++ b/packages/hero/stories/it-hero.mdx
@@ -10,7 +10,7 @@ import * as HeroStories from './it-hero.stories';
 
 ## Cosa fa
 
-Il componente Hero (`it-hero`) è una sezione a tutta larghezza che mette in evidenza contenuti in apertura di pagina con un grande impatto visivo, per invogliare gli utenti a continuare la navigazione.
+Il componente Hero (`<it-hero>`) è una sezione a tutta larghezza che mette in evidenza contenuti in apertura di pagina con un grande impatto visivo, per invogliare gli utenti a continuare la navigazione.
 
 [Approfondisci quando e come usare il componente Hero](https://designers.italia.it/design-system/componenti/hero/)
 
@@ -34,13 +34,13 @@ Considera un hero come una copertina o un banner molto in evidenza:
 
 ## Accessibilità
 
-- Se includi contenuti testuali, usa il corretto livello `h` per il titolo (`h1`-`h6`), in base alla gerarchia dei contenuti della pagina.  Il componente calcolerà automaticamente l'attributo `aria-labelledby` facendolo puntare al primo heading disponibile.
+- Se includi contenuti testuali, usa il corretto livello `h` per il titolo (`<h1>`-`<h6>`), in base alla gerarchia dei contenuti della pagina.  Il componente calcolerà automaticamente l'attributo `aria-labelledby` facendolo puntare al primo heading disponibile.
 - Se non è presente alcun heading nel testo del componente, i lettori di schermo annunceranno la sezione in modo generico, senza ulteriori dettagli. In questo caso, oppure se usi la variante con sola immagine, imposta sempre l'attributo `it-aria-label` sul tag `<it-hero>` per fornire un'etichetta descrittiva.
 - Se usi la variante con testo e immagine di sfondo, verifica che ci sia sempre contrasto adeguato tra testo e sfondo.
 - Valuta sempre con attenzione l'opportunità di usare più Hero nella stessa pagina.
 
 ## Con immagine
-Per mostrare una immagine di sfondo nel componente `it-hero`, inserisci l'immagine nello slot `background` dedicato.
+Per mostrare una immagine di sfondo nel componente `<it-hero>`, inserisci l'immagine nello slot `background` dedicato.
 
 Ricordati di impostare l'attributo `it-aria-label` sul tag `<it-hero>` per indicare ai lettori di schermo di cosa si tratta.
 
@@ -54,7 +54,7 @@ Per aggiungere contenuti testuali, inserisci il testo nello slot `text` dedicato
 <span class="text">Accessibilità dei contenuti testuali</span>
 </div>
 <p>
-Usa il corretto livello `h` per il titolo (`h1`-`h6`), in base alla gerarchia dei contenuti su pagina.
+Usa il corretto livello `h` per il titolo (`<h1>`-`<h6>`), in base alla gerarchia dei contenuti su pagina.
 </p>
 </div>
 </div>

--- a/packages/input/stories/it-input-calendar.mdx
+++ b/packages/input/stories/it-input-calendar.mdx
@@ -9,7 +9,7 @@ import * as Stories from './it-input-calendar.stories';
 <description>Campo per selezionare una data all'interno di un calendario o inserirla manualmente.</description>
 
 ## Cosa fa
-Il componente Datepicker (`it-input` con `type="date"`), consente all’utente di selezionare una data specifica, sia digitandola manualmente che scegliendola da un calendario.
+Il componente Datepicker (`<it-input>` con `type="date"`), consente all’utente di selezionare una data specifica, sia digitandola manualmente che scegliendola da un calendario.
 
 [Approfondisci come e quando usare il componente Datepicker](https://designers.italia.it/design-system/componenti/datepicker/)
 

--- a/packages/input/stories/it-input-number.mdx
+++ b/packages/input/stories/it-input-number.mdx
@@ -8,7 +8,7 @@ import * as Stories from './it-input-number.stories';
 <description>Campo di inserimento di un valore numerico, con pulsanti per incrementarlo o decrementarlo.</description>
 
 ## Cosa fa
-Il componente Number input (`it-input` con `type="number"`) permette all’utente di inserire un numero specifico digitandolo manualmente o selezionandolo tramite appositi pulsanti che incremenatano o diminuiscono un valore numerico di partenza.
+Il componente Number input (`<it-input>` con `type="number"`) permette all’utente di inserire un numero specifico digitandolo manualmente o selezionandolo tramite appositi pulsanti che incremenatano o diminuiscono un valore numerico di partenza.
 
 Aiuta a prevenire errori e facilita l'inserimento dei dati, per questo è particolarmente utile quando bisogna indicare quantità, codici numerici e intervalli di valori con precisione.
 

--- a/packages/input/stories/it-input-time.mdx
+++ b/packages/input/stories/it-input-time.mdx
@@ -8,7 +8,7 @@ import * as Stories from './it-input-time.stories';
 <description>Campo per selezionare un orario all'interno di un form.</description>
 
 ## Cosa fa
-Il componente Timepicker (`it-input` con `type="time"`) consente all'utente di selezionare un orario con ore e minuti, digitandolo manualmento o selezionando opzioni prestabiliti.
+Il componente Timepicker (`<it-input>` con `type="time"`) consente all'utente di selezionare un orario con ore e minuti, digitandolo manualmento o selezionando opzioni prestabiliti.
 È particolarmente utile per flussi di interazione che prevedono la comunicazione di un orario, come la prenotazione di appuntamenti o di posti per un evento.
 
 [Approfondisci come e quando usare il componente Timepicker](https://designers.italia.it/design-system/componenti/timepicker/)

--- a/packages/input/stories/it-input.mdx
+++ b/packages/input/stories/it-input.mdx
@@ -8,7 +8,7 @@ import * as Stories from './it-input.stories';
 <description>Campi per l'inserimento di dati testuali, numerici, in forma libera o in formati specifici, all'interno di un form</description>
 
 ## Cosa fa
-Il componente `it-input` consente all’utente di inserire dati testuali o numerici, sia in forma libera che secondo formati prestabiliti, all’interno di moduli (form).
+Il componente `<it-input>` consente all’utente di inserire dati testuali o numerici, sia in forma libera che secondo formati prestabiliti, all’interno di moduli (form).
 È ideale per raccogliere informazioni brevi (come nomi, email, telefono) o lunghe (come descrizioni), nonché per supportare varianti specifiche come password e aree di testo.
 Si utilizza quando si vuole dare all’utente la possibilità di digitare direttamente un valore e non semplicemente selezionarlo da un elenco di opzioni.
 

--- a/packages/megamenu/stories/it-megamenu.mdx
+++ b/packages/megamenu/stories/it-megamenu.mdx
@@ -9,9 +9,9 @@ import * as Stories from './it-megamenu.stories';
 
 ## Cosa fa
 
-Il componente Megamenu (`it-megamenu`) implementa un sottomenu con elenchi di link e informazioni correlate per semplificare la navigazione di una sezione di un sito.
+Il componente Megamenu (`<it-megamenu>`) implementa un sottomenu con elenchi di link e informazioni correlate per semplificare la navigazione di una sezione di un sito.
 
-Il megamenu è una estensione del componente `it-dropdown` per la navbar `<nav>` del sito.
+Il megamenu è una estensione del componente `<it-dropdown>` per la navbar `<nav>` del sito.
 
 [Approfondisci quando e come usare il componente Megamenu](https://designers.italia.it/design-system/componenti/megamenu/)
 
@@ -27,15 +27,15 @@ Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto
 
 - Usa i megamenu solo per la navigazione principale del sito e con moderazione, testando sempre la loro efficacia con gli utenti.
 
-- Per una corretta gestione del megamenu su mobile, è necessario che il componente sia inserito all'interno del componente `<it-header>`. Per maggiori dettagli, su come includere `it-megamenu` nell'header, consulta la [documentazione del componente Header](?path=/docs/componenti-header--documentazione).
+- Per una corretta gestione del megamenu su mobile, è necessario che il componente sia inserito all'interno del componente `<it-header>`. Per maggiori dettagli, su come includere `<it-megamenu>` nell'header, consulta la [documentazione del componente Header](?path=/docs/componenti-header--documentazione).
 
 - Puoi accostare più megamenu nella navbar per dare accesso a sezioni diverse del sito.
 
 - Usa il megamenu con parsimonia per via della sua natura di interazione complessa, testando sempre la sua efficacia con gli utenti.
 
-- Un link con classe `active` indica la sezione corrente.
+- Un link con classe `.active` indica la sezione corrente.
 
-- Un elemento `<it-dropdown-item>` interno al megamenu con classe `active` indica la pagina corrente.
+- Un elemento `<it-dropdown-item>` interno al megamenu con classe `.active` indica la pagina corrente.
 
 
 Il componente `<it-megamenu>` espone i seguenti slot:
@@ -66,14 +66,14 @@ La variante base può contenere liste di voci di navigazione organizzate su più
 ## Con link “Esplora la sezione”
 Come nella variante completa, puoi aggiungere un link **“Esplora la sezione X”** come primo link.
 
-Un link `it-heading-link` con classe `active` indica la sezione corrente del sito.
+Un link `.it-heading-link` con classe `.active` indica la sezione corrente del sito.
 
 <Canvas of={Stories.MegamenuEsploraSezione} />
 
 ## Con link “Esplora tutti”
 Nel caso le voci da mostrare fossero numerose, puoi aggiungere un link **“Esplora tutti i contenuti Y”** che porta a una lista completa.
 
-Un link `it-footer-link` con classe `active` indica la sezione corrente del sito.
+Un link `.it-footer-link` con classe `.active` indica la sezione corrente del sito.
 
 <Canvas of={Stories.MegamenuEsploraTutti} />
 

--- a/packages/modal/stories/it-modal.mdx
+++ b/packages/modal/stories/it-modal.mdx
@@ -40,7 +40,7 @@ Il componente `<it-modal>` è composto dai seguenti slot:
 - `content` (**obbligatorio**), per inserire il contenuto principale della modale;
 - `footer`, per le azioni della modale come pulsanti di conferma o cancellazione ed eventuali elementi aggiuntivi.
 
-Inserisci il trigger per l'apertura della modale nello slot `trigger`, come mostrato negli esempi con il componente `it-button`.
+Inserisci il trigger per l'apertura della modale nello slot `trigger`, come mostrato negli esempi con il componente `<it-button>`.
 
 Definisci il titolo della modale tramite lo slot `header` o l’attributo `modal-title`. Se non vuoi mostrare un titolo, fornisci un’etichetta accessibile tramite l’attributo it-aria-label.
 
@@ -56,7 +56,7 @@ Imposta manualmente nello slot `footer` eventuali azioni di conferma, cancellazi
       Il componente espone i metodi pubblici `show()`, `hide()` e `toggle()`, rispettivamente per aprire/chiudere la modale e commutarne lo stato via codice.
     </p>
     <p class="font-weight-bold">
-      <strong>Non è necessaria l'implementazione via JS per l'apertura della modale, in quanto il componente gestisce automaticamente l'apertura al click dell'`it-button` o del pulsante inserito nello slot `trigger`, ma è possibile implementare un'apertura manuale via JS qualora fosse necessario, ad esempio in caso di trigger non convenzionali o per esigenze specifiche di interazione e/o logiche di business.</strong>
+      <strong>Non è necessaria l'implementazione via JS per l'apertura della modale, in quanto il componente gestisce automaticamente l'apertura al click dell'`<it-button>` o del pulsante inserito nello slot `trigger`, ma è possibile implementare un'apertura manuale via JS qualora fosse necessario, ad esempio in caso di trigger non convenzionali o per esigenze specifiche di interazione e/o logiche di business.</strong>
     </p>
     <p class="font-weight-bold">
     Al fine di garantire la completa compatibilità con tutti i moderni framework Javascript,
@@ -87,7 +87,7 @@ Imposta manualmente nello slot `footer` eventuali azioni di conferma, cancellazi
 
 ## Accessibilità
 
-Il componente `it-modal`:
+Il componente `<it-modal>`:
 - implementa le specifiche ARIA [WAI-ARIA Authoring Practices 1.1 dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/) e gestisce automaticamente gli attributi ARIA necessari per garantire l'accessibilità della modale;
 - rispetta le preferenze di riduzione del movimento impostate dall'utente a livello di sistema operativo, disabilitando le animazioni se l'impostazione è rilevata a livello di browser;
 - gestisce automaticamente il focus all'interno della modale quando viene aperta, spostandolo sul primo elemento interattivo disponibile e ciclando poi il focus all'interno della modale stessa attraverso una focus trap;
@@ -103,10 +103,10 @@ Il componente supporta la chiusura della modale tramite il tasto ESC e/o cliccan
 Il focus viene ripristinato sull'elemento di trigger una volta che la modale viene chiusa.
 
 Per realizzare modali accessibili a tutti gli utenti, assicurati di:
-- popolare lo slot `trigger` esclusivamente con elementi interattivi semanticamente corretti, come `it-button`, `button` o che supportino il ruolo di button.
+- popolare lo slot `trigger` esclusivamente con elementi interattivi semanticamente corretti, come `<it-button>`, `<button>` o che supportino il ruolo di button.
 - popolare lo slot `header` o uno tra gli attributi `modal-title` e `it-aria-label` per fornire un'etichetta accessibile alla modale. Se non vuoi mostrare il titolo, devi usare l'attributo `it-aria-label`;
 - in caso di contenuti che includono strutture semantiche (come liste, tabelle, paragrafi multipli), non valorizzare l'attributo `modal-description` e/o non inserire contenuto nello slot `description`. ([Approfondisci ruoli, stati e proprietà WAI-ARIA](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#wai-ariaroles,states,andproperties));
-- includi sempre un pulsante di chiusura della modale tramite l'attributo `close-button`, o implementalo manualmente nello slot `footer` tramite un pulsante `it-button`.
+- includi sempre un pulsante di chiusura della modale tramite l'attributo `close-button`, o implementalo manualmente nello slot `footer` tramite un pulsante `<it-button>`.
 
 ## Con pulsante di chiusura
 
@@ -139,7 +139,7 @@ Il componente `<it-modal>` offre alcune varianti predefinite per adattarsi a div
 
 ### Modale con icona
 
-Per dare enfasi visiva, puoi aggiungere un'icona nell'header inserendo un componente `it-icon` nello slot `header-icon`. Valorizza l'attributo `variation` con valore `alert` per ottenere il layout corretto.
+Per dare enfasi visiva, puoi aggiungere un'icona nell'header inserendo un componente `<it-icon>` nello slot `header-icon`. Valorizza l'attributo `variation` con valore `alert` per ottenere il layout corretto.
 
 <Canvas of={Stories.ConIcona} />
 

--- a/packages/navscroll/stories/it-navscroll.mdx
+++ b/packages/navscroll/stories/it-navscroll.mdx
@@ -11,7 +11,7 @@ import * as Stories from './it-navscroll.stories';
 
 ## Cosa fa
 
-Il componente Navscroll (`it-navscroll`), declinazione del [componente Sidebar](?path=/docs/componenti-sidebar--documentazione), è una barra di navigazione laterale che, tramite una lista di ancore, permette di creare un indice utile a saltare velocemente alle sezioni e ai contenuti presenti su una stessa pagina.
+Il componente Navscroll (`<it-navscroll>`), declinazione del [componente Sidebar](?path=/docs/componenti-sidebar--documentazione), è una barra di navigazione laterale che, tramite una lista di ancore, permette di creare un indice utile a saltare velocemente alle sezioni e ai contenuti presenti su una stessa pagina.
 
 [Approfondisci come e quando usare il componente Navscroll](https://designers.italia.it/design-system/componenti/navscroll/)
 
@@ -30,9 +30,9 @@ Restringi la larghezza della finestra per vedere cosa succede su dispositivi mob
 
 ## Indicazioni generali
 
-Per configurare correttamente il componente `it-navscroll`:
+Per configurare correttamente il componente `<it-navscroll>`:
 
-- definisci le sezioni di pagina con intestazioni semantiche in ordine corretto (`h2`, `h3`, ecc.);
+- definisci le sezioni di pagina con intestazioni semantiche in ordine corretto (`<h2>`, `<h3>`, ecc.);
 - aggiungi nel componente voci di navigazione sintetiche e corrispondenti ai titoli di sezione su pagina;
 - aggiungi per ogni link l’attributo `href` con il valore dell’id relativo all’elemento correlato in pagina, `href="#idElemento"`;
 - posiziona il componente a destra o a sinistra del contenuto principale della pagina;
@@ -94,7 +94,7 @@ Imposta l'attributo `position="top"` per mostrare il trigger di apertura della n
 
 ## Con barra di progresso
 
-Per mostrare la barra di progresso, aggiungi il componente `<it-progress>` all'interno del div con classe `link-list-wrapper`, assegnandogli la classe `class="it-navscroll-progressbar"`.
+Per mostrare la barra di progresso, aggiungi il componente `<it-progress>` all'interno del `<div>` con classe `.link-list-wrapper`, assegnandogli la classe `.it-navscroll-progressbar`.
 
 ```html
 <it-progress type="bar" value="0" class="it-navscroll-progressbar" aria-label="Progress bar"></it-progress>

--- a/packages/notification/stories/it-notification.mdx
+++ b/packages/notification/stories/it-notification.mdx
@@ -34,7 +34,7 @@ Passa alla sezione [Attivazione tramite codice](#attivazione-tramite-codice) per
 
 ## Accessibilità
 
-Il componente utilizza il tag `h2` per il titolo delle notifiche per impostazione predefinita.
+Il componente utilizza il tag `<h2>` per il titolo delle notifiche per impostazione predefinita.
 Utilizza il tag `h` corretto a seconda del contesto.
 Usa l'attributo `heading-level` per impostarlo.
 
@@ -92,7 +92,7 @@ Esempi delle quattro posizioni fisse possibili.
 
 ## Attivazione tramite codice
 
-Puoi mostrare una notifica chiamando il metodo `show` di un elemento `it-notification`.
+Puoi mostrare una notifica chiamando il metodo `show` di un elemento `<it-notification>`.
 Puoi passare come parametro il valore in millisecondi di permanenza della notifica.
 Se non viene specificato viene usato il valore dell'attributo `timeout`, oppure viene usato il valore predefinito di 3 secondi.
 
@@ -109,7 +109,7 @@ Questo è il comportamento di default che ottieni quando non imposti l'attributo
 Questo è un esempio di come rimuovere manualmente le notifiche quando imposti l'attributo `dismissable`.
 Il click sul pulsante di chiusura interno alla notifica è automaticamente configurato per nasconderla.
 
-Puoi inoltre controllarne la chiusura dall'esterno programmaticamente, chiamando il metodo `hide` dell'elemento `it-notification`.
+Puoi inoltre controllarne la chiusura dall'esterno programmaticamente, chiamando il metodo `hide` dell'elemento `<it-notification>`.
 
 <Canvas of={Stories.AttivazioneEdEliminazione} />
 

--- a/packages/pagination/stories/it-pagination.mdx
+++ b/packages/pagination/stories/it-pagination.mdx
@@ -8,7 +8,7 @@ import * as PaginationStories from './it-pagination.stories';
 <description>Barra di navigazione per scorrere una lista di contenuti disposti su più pagine.</description>
 
 ## Cosa fa
-Il componente Pagination (`it-pagination`) permette di suddividere in più pagine elenchi di contenuti o dati correlati che non possono essere visualizzati tutti insieme. È particolarmente utile per risultati di ricerca ed elenchi di prodotti, servizi o notizie.
+Il componente Pagination (`<it-pagination>`) permette di suddividere in più pagine elenchi di contenuti o dati correlati che non possono essere visualizzati tutti insieme. È particolarmente utile per risultati di ricerca ed elenchi di prodotti, servizi o notizie.
 
 [Approfondisci quando e come usare il componente Pagination](https://designers.italia.it/design-system/componenti/paginazione/)
 
@@ -27,32 +27,32 @@ Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto
 
 Il componente Pagination è composto da due elementi:
 
-- `it-pagination`, il contenitore della paginazione che gestisce lo stato della pagina corrente;
-- `it-pagination-item`, il singolo elemento della paginazione che contiene il link alla pagina.
+- `<it-pagination>`, il contenitore della paginazione che gestisce lo stato della pagina corrente;
+- `<it-pagination-item>`, il singolo elemento della paginazione che contiene il link alla pagina.
 
-Per garantire la massima flessibilità e compatibilità con diversi framework, il componente `it-pagination` non genera automaticamente gli elementi di paginazione. È necessario aggiungere manualmente gli elementi `it-pagination-item` come figli di `it-pagination`, in modo da poter personalizzare i link e il loro comportamento.
+Per garantire la massima flessibilità e compatibilità con diversi framework, il componente `<it-pagination>` non genera automaticamente gli elementi di paginazione. È necessario aggiungere manualmente gli elementi `<it-pagination-item>` come figli di `<it-pagination>`, in modo da poter personalizzare i link e il loro comportamento.
 
-All'interno di ogni `it-pagination-item`, puoi inserire un link (ad esempio un elemento `<a>`) per gestire la navigazione tra le pagine: se stai usando un framework come React, NextJS, Angular o Vue.js, puoi integrare i componenti di routing del framework all'interno degli elementi `it-pagination-item`. Segui le indicazioni del framework che stai usando per gestire la navigazione tra le pagine e/o integrare il tuo sistema di paginazione.
+All'interno di ogni `<it-pagination-item>`, puoi inserire un link (ad esempio un elemento `<a>`) per gestire la navigazione tra le pagine: se stai usando un framework come React, NextJS, Angular o Vue.js, puoi integrare i componenti di routing del framework all'interno degli elementi `<it-pagination-item>`. Segui le indicazioni del framework che stai usando per gestire la navigazione tra le pagine e/o integrare il tuo sistema di paginazione.
 
-Il componente `it-pagination` supporta i seguenti slot:
+Il componente `<it-pagination>` supporta i seguenti slot:
 
-- **default**, per gli elementi `it-pagination-item`;
+- **default**, per gli elementi `<it-pagination-item>`;
 - **prev**, per il pulsante/link di navigazione alla pagina precedente;
 - **next**, per il pulsante/link di navigazione alla pagina successiva;
 - **page-changer**, per un eventuale selettore di pagina;
 - **jump-to-page**, per un eventuale campo di salto a una pagina specifica;
 - **total**, per mostrare il numero totale di pagine.
 
-Il componente `it-pagination-item` supporta i seguenti attributi:
+Il componente `<it-pagination-item>` supporta i seguenti attributi:
 - `page` (**obbligatorio**), numero della pagina rappresentata dall'elemento;
 - `current` (opzionale), indica se l'elemento rappresenta la pagina corrente;
 - `disabled` (opzionale), indica se l'elemento è disabilitato.
 
-Il componente `it-pagination-item` espone il solo slot **default** per inserire il link alla pagina.
+Il componente `<it-pagination-item>` espone il solo slot **default** per inserire il link alla pagina.
 
 ## Accessibilità
 
-Il componente `it-pagination` è progettato per essere accessibile e conforme alle linee guida WCAG:
+Il componente `<it-pagination>` è progettato per essere accessibile e conforme alle linee guida WCAG:
 - gli elementi di paginazione sono implementati come link, consentendo agli utenti di navigare tra le pagine utilizzando il tasto Tab e attivare i link con il tasto Invio o la barra spaziatrice;
 - il componente utilizza ruoli ARIA appropriati per indicare la struttura della paginazione ai lettori di schermo;
 - l'elemento della pagina corrente è indicato con l'attributo `aria-current="page"` per informare gli utenti dei lettori di schermo;
@@ -62,8 +62,8 @@ Il componente `it-pagination` è progettato per essere accessibile e conforme al
 
 Per garantire la massma accesibilità, ricordati di:
 - fornire etichette significative per i link di navigazione alla pagina precedente e successiva quando utilizzi gli slot `prev` e `next`;
-- fornire sempre un link semanticamente valido all'interno di ogni elemento `it-pagination-item`;
-- valorizzare sempre l'attributo `it-aria-label` sull'elemento `it-pagination` per descrivere il contesto della paginazione (ad esempio "Paginazione articoli", "Paginazione risultati di ricerca", ecc.).
+- fornire sempre un link semanticamente valido all'interno di ogni elemento `<it-pagination-item>`;
+- valorizzare sempre l'attributo `it-aria-label` sull'elemento `<it-pagination>` per descrivere il contesto della paginazione (ad esempio "Paginazione articoli", "Paginazione risultati di ricerca", ecc.).
 
 <div class="callout callout-warning">
   <div class="callout-inner">
@@ -71,7 +71,7 @@ Per garantire la massma accesibilità, ricordati di:
       <span class="text">Nota sui test di accessibilità</span>
     </div>
     <p>
-      Axe e altri strumenti di analisi statica possono segnalare falsi positivi quando analizzano il componente `it-pagination` a causa del limitato supporto per i Web Components. La struttura accessibile effettiva è corretta, come confermato dall'Accessibility Tree e dai test manuali con lettori di schermo.
+      Axe e altri strumenti di analisi statica possono segnalare falsi positivi quando analizzano il componente `<it-pagination>` a causa del limitato supporto per i Web Components. La struttura accessibile effettiva è corretta, come confermato dall'Accessibility Tree e dai test manuali con lettori di schermo.
     </p>
   </div>
 </div>
@@ -94,7 +94,7 @@ Per mostrare del testo come pulsante di navigazione, usa gli slot `prev` e `next
 
 In modalità responsive (attiva di default), su schermi di piccole dimensioni, il componente nasconde gli elementi di paginazione non attivi e mostra soltanto l'elemento della pagina corrente.
 
-Se vuoi disabilitare questo comportamento, aggiungi l'attributo `disable-responsive` a `it-pagination`. Dovrai poi gestire autonomamento l'aspetto della paginazione sui diversi dispositivi.
+Se vuoi disabilitare questo comportamento, aggiungi l'attributo `disable-responsive` a `<it-pagination>`. Dovrai poi gestire autonomamento l'aspetto della paginazione sui diversi dispositivi.
 
 <Canvas of={PaginationStories.Responsive} />
 
@@ -140,7 +140,7 @@ Questo esempio di implementazione usa un elemento `<it-input>` di tipo numero.
 
 ## Allineamento
 
-Per gestire l'allineamento del componente `it-pagination`, usa gli attributi:
+Per gestire l'allineamento del componente `<it-pagination>`, usa gli attributi:
 
 - `start` (default), per allinearlo a sinistra;
 - `center`, per allinearlo al centro;
@@ -165,7 +165,7 @@ Il componente emette i seguenti eventi custom:
 - `it-pagination-change`, quando la pagina corrente cambia. L'evento fornisce il numero della nuova pagina selezionata nel dettaglio dell'evento (`event.detail`).
 
 ## Personalizzazione degli stili
-Per personalizzare gli stili, usa i selettori `::part` dedicati di `it-pagination`:
+Per personalizzare gli stili, usa i selettori `::part` dedicati di `<it-pagination>`:
 - `::part(pagination-list)`, per lo stile dell'elemento `<ul>` che contiene gli elementi di paginazione;
 - `::part(current-page-simple-mode)`, per lo stile dell'elemento che rappresenta la pagina corrente in modalità simple;
 - `::part(total-pages-simple-mode)`, per lo stile dell'elemento che rappresenta il numero totale di pagine in modalità simple.

--- a/packages/popover/stories/it-popover.mdx
+++ b/packages/popover/stories/it-popover.mdx
@@ -9,7 +9,7 @@ import * as PopoverStories from './it-popover.stories';
 
 ## Cosa fa
 
-Il componente Popover (`it-popover`) visualizza contenuti in overlay posizionati dinamicamente rispetto a un elemento trigger.
+Il componente Popover (`<it-popover>`) visualizza contenuti in overlay posizionati dinamicamente rispetto a un elemento trigger.
 Utilizza [Floating UI](https://floating-ui.com/) per il posizionamento intelligente e si adatta automaticamente allo spazio disponibile.
 
 Il componente implementa le buone pratiche UX definite da [Polaris (Shopify)](https://polaris.shopify.com/components/overlays/popover), [Apple HIG](https://developer.apple.com/design/human-interface-guidelines/popovers) e [Material Design](https://m3.material.io/).
@@ -75,7 +75,7 @@ Il posizionamento si adatta automaticamente allo spazio disponibile.
 
 Per aggiungere un'icona in testa al titolo e un link in coda al contenuto:
 - includi l'icona nell'elemento usato come intestazione (ad esempio, l'elemento `<h4>` nell'esempio), subito prima del vero e proprio titolo;
-- inserisci il link dopo il contenuto testuale, con classe `popover-inner-link`.
+- inserisci il link dopo il contenuto testuale, con classe `.popover-inner-link`.
 
 <Canvas of={PopoverStories.ConIconaELink} />
 
@@ -90,7 +90,7 @@ Valuta anche l'utilizzo di un [Tooltip](/docs/componenti-tooltip--documentazione
 
 ### Attivazione tramite hover e focus
 
-Per implementare l'attivazione su hover ti serve un riferimento al pulsante `trigger` e al componente `it-popover` stesso nel tuo codice JavaScript.
+Per implementare l'attivazione su hover ti serve un riferimento al pulsante `trigger` e al componente `<it-popover>` stesso nel tuo codice JavaScript.
 
 ```javascript
 const trigger = document.querySelector('it-button[slot="trigger"]');

--- a/packages/progress/stories/it-progress.mdx
+++ b/packages/progress/stories/it-progress.mdx
@@ -10,7 +10,7 @@ Indicatori di stato attivo e di avanzamento di un’operazione.
 
 ## Cosa fa
 
-Il componente `it-progress` rappresenta lo stato di avanzamento o di elaborazione di un'operazione come il caricamento di un file o l’invio dei dati di un modulo.
+Il componente `<it-progress>` rappresenta lo stato di avanzamento o di elaborazione di un'operazione come il caricamento di un file o l’invio dei dati di un modulo.
 
 Può essere usato in tre modalità, tramite l'attributo `type`:
 
@@ -56,7 +56,7 @@ Non dimenticare di fornire un testo esplicativo per gli Screen Reader tramite l'
 ### Indeterminato
 
 Quando non è possibile stabilire una percentuale di progressione,
-utilizza una Progress Bar di tipo indeterminato, aggiungendo l'attributo `indeterminate` al componente `it-progress`.
+utilizza una Progress Bar di tipo indeterminato, aggiungendo l'attributo `indeterminate` al componente `<it-progress>`.
 
 <Canvas of={ProgressStories.Indeterminato} />
 

--- a/packages/rating/stories/it-rating.mdx
+++ b/packages/rating/stories/it-rating.mdx
@@ -10,7 +10,7 @@ import * as RatingStories from './it-rating.stories';
 
 
 ## Cosa fa
-Il componente Rating (`it-rating`) permette alle persone di esprimere una valutazione in modo semplice e intuitivo su un prodotto, un servizio digitale o la chiarezza informativa di una pagina.
+Il componente Rating (`<it-rating>`) permette alle persone di esprimere una valutazione in modo semplice e intuitivo su un prodotto, un servizio digitale o la chiarezza informativa di una pagina.
 
 [Approfondisci quando e come usare il componente Rating](https://designers.italia.it/design-system/componenti/rating/)
 

--- a/packages/section/stories/it-section.mdx
+++ b/packages/section/stories/it-section.mdx
@@ -9,7 +9,7 @@ import * as Stories from './it-section.stories';
 
 ## Cosa fa
 
-Il componente Section (`it-section`), in italiano sezione, rappresenta un contenitore visivo per introdurre sezioni di contenuto con o senza immagine.
+Il componente Section (`<it-section>`), in italiano sezione, rappresenta un contenitore visivo per introdurre sezioni di contenuto con o senza immagine.
 È utile per organizzare e suddividere contenuti particolarmente ampi e complessi, permettendo agli utenti di navigare facilmente tra le diverse parti.
 
 
@@ -24,7 +24,7 @@ Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto
 
 ## Accessibilità
 
-Il componente `it-section` è progettato per essere accessibile:
+Il componente `<it-section>` è progettato per essere accessibile:
 
 - il tag `<section>` generato dal componente viene automaticamente associato al primo heading (h1-h6) presente nel contenuto tramite l'attributo `aria-labelledby`. Se l'heading non ha un id, il componente ne genera uno automaticamente;
 - le immagini fornite tramite l'attributo `image` sono considerate **decorative**: vengono rese con `alt=""` e `aria-hidden="true"`, quindi non vengono annunciate dagli screen reader.
@@ -32,7 +32,7 @@ Il componente `it-section` è progettato per essere accessibile:
 Per garantire un'esperienza accessibile:
 
 - assicurati che ogni sezione contenga almeno un'intestazione semantica (h2, h3, ecc.) che descriva il contenuto della sezione;
-- usa `it-section` per raggruppamenti semantici con particolari necessità di varianti di stile e/o inserimento di immagini di sfondo, mentre se stai implementando un semplice contenitore considera l'uso di `<section>`, `<div>` o di altri elementi HTML semantici appropriati.
+- usa `<it-section>` per raggruppamenti semantici con particolari necessità di varianti di stile e/o inserimento di immagini di sfondo, mentre se stai implementando un semplice contenitore considera l'uso di `<section>`, `<div>` o di altri elementi HTML semantici appropriati.
 
 
 ## Varianti di sfondo

--- a/packages/select/stories/it-select.mdx
+++ b/packages/select/stories/it-select.mdx
@@ -9,7 +9,7 @@ import * as Stories from './it-select.stories';
 <description>Campo di selezione di un form per scegliere una o più opzioni da una lista predefinita di valori.</description>
 
 ## Cosa fa
-Il componente Select (it-select) permette agli utenti di selezionare uno o più elementi all'interno di un elenco di opzioni predefinite.
+Il componente Select (`<it-select>`) permette agli utenti di selezionare uno o più elementi all'interno di un elenco di opzioni predefinite.
 
 [Approfondisci come e quando usare il componente Select](https://designers.italia.it/design-system/componenti/select/)
 
@@ -33,7 +33,7 @@ Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto
 - L'etichetta viene associata automaticamente alla select tramite l'attributo `for` generato.
 
 {/* ## Select multipla
-Per abilitare la selezione multipla di valori in un `it-select`, aggiungi l'attributo `multiple`.
+Per abilitare la selezione multipla di valori in un `<it-select>`, aggiungi l'attributo `multiple`.
 
 **Attenzione!** In questi casi, il [componente Checkbox](/docs/componenti-form-checkbox--documentazione) è un'alternativa più accessibile. */}
 
@@ -41,12 +41,12 @@ Per abilitare la selezione multipla di valori in un `it-select`, aggiungi l'attr
 
 
 ## Select disabilitata
-Per disabilitare un `it-select`, aggiungi l'attributo `disabled`.
+Per disabilitare un `<it-select>`, aggiungi l'attributo `disabled`.
 <Canvas of={Stories.Disabled} />
 
 
 ## Select con gruppi
-Per ottenere un `it-select` con raggruppamenti, usa il tag HTML `<optgroup>` per raggruppare le `<option>` al suo interno.
+Per ottenere un `<it-select>` con raggruppamenti, usa il tag HTML `<optgroup>` per raggruppare le `<option>` al suo interno.
 <Canvas of={Stories.Groups} />
 
 ## Testo di supporto

--- a/packages/skiplinks/stories/it-skiplinks.mdx
+++ b/packages/skiplinks/stories/it-skiplinks.mdx
@@ -9,7 +9,7 @@ import * as Stories from './it-skiplinks.stories';
 
 ## Cosa fa
 
-Il componente Skiplinks (`it-skiplinks`) crea scorciatoie di navigazione che consentono agli utenti di andare direttamente ai contenuti principali di una pagina particolarmente complessa da navigare. Sono utili per chi usa la tastiera o tecnologie assistive come i lettori di schermo.
+Il componente Skiplinks (`<it-skiplinks>`) crea scorciatoie di navigazione che consentono agli utenti di andare direttamente ai contenuti principali di una pagina particolarmente complessa da navigare. Sono utili per chi usa la tastiera o tecnologie assistive come i lettori di schermo.
 
 [Approfondisci come e quando usare il componente Skiplinks](https://designers.italia.it/design-system/componenti/skiplinks/)
 

--- a/packages/stepper/stories/it-stepper.mdx
+++ b/packages/stepper/stories/it-stepper.mdx
@@ -9,8 +9,8 @@ import * as Stories from './it-stepper.stories';
 
 ## Cosa fa
 
-Il componente `it-stepper` mostra lo stato di avanzamento di una procedura composta da più passaggi logici.
-Ogni passaggio viene definito con un elemento `it-stepper-step` inserito all'interno del componente.
+Il componente `<it-stepper>` mostra lo stato di avanzamento di una procedura composta da più passaggi logici.
+Ogni passaggio viene definito con un elemento `<it-stepper-step>` inserito all'interno del componente.
 
 Lo stepper è composto da intestazione, area contenuto e navigazione.
 Puoi mostrare tutte le aree insieme oppure nasconderne alcune quando devi riprodurre solo l'intestazione, solo l'avanzamento o un flusso con salvataggio e conferma.
@@ -50,7 +50,7 @@ La variante predefinita (`text`) mostra l'etichetta di ciascun passo e il suo st
 ### Testo e icone
 
 La variante `icons` mostra un'icona prima dell'etichetta di ciascun passo.
-Per ogni `it-stepper-step` puoi specificare il nome dell'icona tramite l'attributo `icon`, ad esempio `it-calendar`, `it-lock` o `it-settings`.
+Per ogni `<it-stepper-step>` puoi specificare il nome dell'icona tramite l'attributo `icon`, ad esempio `it-calendar`, `it-lock` o `it-settings`.
 
 <Canvas of={Stories.TestoEIcone} />
 

--- a/packages/sticky/stories/it-sticky.mdx
+++ b/packages/sticky/stories/it-sticky.mdx
@@ -9,7 +9,7 @@ import * as Stories from './it-sticky.stories';
 
 ## Cosa fa
 
-Il componente Sticky (`it-sticky`) mantiene un elemento visibile mentre l'utente scorre la pagina. Questo è particolarmente utile per menu di navigazione, call-to-action importanti, pulsanti di contatto o supporto che devono sempre rimanere accessibili.
+Il componente Sticky (`<it-sticky>`) mantiene un elemento visibile mentre l'utente scorre la pagina. Questo è particolarmente utile per menu di navigazione, call-to-action importanti, pulsanti di contatto o supporto che devono sempre rimanere accessibili.
 
 [Approfondisci quando e come usare il componente Sticky](https://designers.italia.it/design-system/componenti/sticky/)
 
@@ -102,7 +102,7 @@ Quando ci sono più componenti sticky sulla pagina, puoi impilarli l'uno sull'al
 ## Position bottom
 
 Impostando `position="bottom"` insieme a `position-type="fixed"`, l'elemento viene agganciato al bordo inferiore del viewport **immediatamente al caricamento della pagina**, senza attendere lo scroll.
-Questo è il comportamento usato internamente da `it-bottom-nav`.
+Questo è il comportamento usato internamente da `<it-bottom-nav>`.
 
 Aggiungendo l'attributo `stackable` è possibile sovrapporre più barre fisse in fondo, che si impileranno verso l'alto in ordine di connessione al DOM.
 
@@ -115,7 +115,7 @@ Aggiungendo l'attributo `stackable` è possibile sovrapporre più barre fisse in
 
 ### Eventi
 
-Il componente `it-sticky` emette questi eventi custom:
+Il componente `<it-sticky>` emette questi eventi custom:
 
 - **it-sticky-on**, quando l'elemento diventa sticky;
 - **it-sticky-off**, quando l'elemento smette di essere sticky.

--- a/packages/tabs/stories/it-tabs.mdx
+++ b/packages/tabs/stories/it-tabs.mdx
@@ -29,20 +29,20 @@ Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto
 
 Il componente Tabs è composto da tre elementi:
 
-- `it-tabs`: contenitore principale che gestisce selezione, ARIA e navigazione da tastiera;
-- `it-tab`: singola scheda trigger, assegnata allo `slot="tab"`. Testo o markup inseriti al suo interno rappresentano l'etichetta;
-- `it-tab-panel`: singolo pannello di contenuto; testo o markup inseriti al suo interno rappresentano il corpo della scheda.
+- `<it-tabs>`: contenitore principale che gestisce selezione, ARIA e navigazione da tastiera;
+- `<it-tab>`: singola scheda trigger, assegnata allo `slot="tab"`. Testo o markup inseriti al suo interno rappresentano l'etichetta;
+- `<it-tab-panel>`: singolo pannello di contenuto; testo o markup inseriti al suo interno rappresentano il corpo della scheda.
 
 Il collegamento tra trigger e pannello avviene tramite:
-- attributo `panel="nome"` su `it-tab`
-- attributo `name="nome"` su `it-tab-panel`
+- attributo `panel="nome"` su `<it-tab>`
+- attributo `name="nome"` su `<it-tab-panel>`
 
-**Assicurati che ogni coppia `it-tab`/`it-tab-panel` in pagina abbia un valore univoco per questi attributi.**
+**Assicurati che ogni coppia `<it-tab>`/`<it-tab-panel>` in pagina abbia un valore univoco per questi attributi.**
 
 ### Attributi del componente it-tab
-Puoi utilizzare l'attributo `disabled` su `it-tab` per disabilitare una scheda, rendendola non selezionabile e non raggiungibile da tastiera.
+Puoi utilizzare l'attributo `disabled` su `<it-tab>` per disabilitare una scheda, rendendola non selezionabile e non raggiungibile da tastiera.
 
-Puoi utilizzare l'attributo `active` su `it-tab` per impostare una scheda come attiva di default all'inizializzazione.
+Puoi utilizzare l'attributo `active` su `<it-tab>` per impostare una scheda come attiva di default all'inizializzazione.
 
 ## Accessibilità
 
@@ -52,7 +52,7 @@ Il componente gestisce automaticamente gli attributi ARIA necessari per l'access
 - `aria-selected` e roving tabindex su tastiera via frecce gestiti automaticamente;
 - `aria-controls` su ogni tab punta all'id del pannello associato;
 - `aria-labelledby` su ogni pannello punta all'id del bottone del tab corrispondente;
-- L'attributo `label` su `it-tabs` fornisce l'`aria-label` della tablist, **consigliato** in termini di accessibilità quando non è presente un'intestazione visiva adiacente. In tal caso, assegna un'id univoco all'intestazione e usa `aria-labelledby` su `it-tabs` per collegarla.
+- L'attributo `label` su `<it-tabs>` fornisce l'`aria-label` della tablist, **consigliato** in termini di accessibilità quando non è presente un'intestazione visiva adiacente. In tal caso, assegna un'id univoco all'intestazione e usa `aria-labelledby` su `<it-tabs>` per collegarla.
 - `aria-keyshortcuts` su ogni tab, dichiara le shortcut da tastiera supportate, che vengono lette dagli screen reader che supportano questo attributo ARIA all'accesso alla tablist. Indicazioni di fallback per screen reader che non supportano `aria-keyshortcuts` sono associate all'attributo `aria-description` del tab attivo, e lette all'accesso al pannello attivo.
 - `aria-description` con indicazioni di fallback per le shortcut da tastiera, lette da tutti gli screen reader all'accesso al pannello attivo. Il testo di questa descrizione è internazionalizzato e personalizzabile tramite la chiave `closeActiveTabHint`.
 <table>
@@ -85,7 +85,7 @@ Il componente gestisce automaticamente gli attributi ARIA necessari per l'access
 <div class="callout callout-warning">
 <div class="callout-inner">
 <div class="callout-title"><span class="text">Attributo label</span></div>
-<p>Quando non è presente un'intestazione collegata ad `it-tabs` tramite `aria-labelledby` o un'intestazione, imposta sempre l'attributo <code>label</code> su <code>it-tabs</code> con una descrizione contestuale. Questo testo viene letto dagli screen reader all'accesso alla tablist.</p>
+<p>Quando non è presente un'intestazione collegata ad `<it-tabs>` tramite `aria-labelledby` o un'intestazione, imposta sempre l'attributo <code>label</code> su <code>&lt;it-tabs&gt;</code> con una descrizione contestuale. Questo testo viene letto dagli screen reader all'accesso alla tablist.</p>
 </div>
 </div>
 
@@ -145,9 +145,9 @@ Puoi utilizzare l'attributo `auto` per espandere i tab al fine di occupare l'int
 
 Le etichette dei tab possono contenere icone, anche non associate a del testo.
 
-In questo caso, ricordati sempre di associare un testo con classe `.visually-hidden` all'interno del tag del tab per garantire l'accessibilità agli screen reader, o di utilizzare l'attributo `label` del componente `it-icon`, se lo utilizzi come trigger senza testo visibile.
+In questo caso, ricordati sempre di associare un testo con classe `.visually-hidden` all'interno del tag del tab per garantire l'accessibilità agli screen reader, o di utilizzare l'attributo `label` del componente `<it-icon>`, se lo utilizzi come trigger senza testo visibile.
 
-Se vuoi variare la dimensione delle icone, utilizza l'attributo `size` di `it-icon` o personalizza la dimensione con CSS.
+Se vuoi variare la dimensione delle icone, utilizza l'attributo `size` di `<it-icon>` o personalizza la dimensione con CSS.
 
 <Canvas of={TabsStories.TabConIcona} />
 
@@ -163,7 +163,7 @@ Puoi utilizzare l'attributo `dark` per ottenere una tablist con sfondo scuro.
 
 ## Effetto fade
 
-Puoi utilizzare l'attributo `fade` di `it-tabs` per fare in modo che i pannelli appaiano con un'animazione di dissolvenza al cambio tab.
+Puoi utilizzare l'attributo `fade` di `<it-tabs>` per fare in modo che i pannelli appaiano con un'animazione di dissolvenza al cambio tab.
 
 <Canvas of={TabsStories.TabFade} />
 
@@ -176,9 +176,9 @@ Valorizzando l'attributo `cards`, i tab assumono un design "card".
 <Canvas of={TabsStories.TabCard} />
 
 ## Tab card con pulsanti aggiungi/elimina
-Puoi utilizzare l'attributo `cards` in combinazione con `dismissible` per ottenere tab di tipo card con pulsante di chiusura integrato. In questo modo, ogni tab diventa rimovibile, e viene aggiunta una icona × all'interno di ogni `it-tab`.
+Puoi utilizzare l'attributo `cards` in combinazione con `dismissible` per ottenere tab di tipo card con pulsante di chiusura integrato. In questo modo, ogni tab diventa rimovibile, e viene aggiunta una icona × all'interno di ogni `<it-tab>`.
 
-In questa configurazione, al click, al double tap da mobile o attraverso le shortcut da tastiera `Delete` e `Backspace` quando un tab è in focus, il tab emette l'evento cancellabile `it-tab-close` con `detail.panel` e, se non viene chiamato `preventDefault()`, **rimuove automaticamente** `it-tab` e `it-tab-panel` dal DOM.
+In questa configurazione, al click, al double tap da mobile o attraverso le shortcut da tastiera `Delete` e `Backspace` quando un tab è in focus, il tab emette l'evento cancellabile `it-tab-close` con `detail.panel` e, se non viene chiamato `preventDefault()`, **rimuove automaticamente** `<it-tab>` e `<it-tab-panel>` dal DOM.
 
 Il focus si sposta sul tab adiacente (successivo o, se non esiste, precedente) prima della rimozione, seguendo il pattern WAI-ARIA APG.
 <Canvas of={TabsStories.TabCardConPulsanti} />
@@ -186,7 +186,7 @@ Il focus si sposta sul tab adiacente (successivo o, se non esiste, precedente) p
 ### Tab card con pulsanti aggiungi/elimina e logica personalizzata
 Puoi intercettare l'evento `it-tab-close` per implementare una logica personalizzata al momento della chiusura di un tab, ad esempio per mostrare una conferma modale prima di procedere con la rimozione. In questo caso, è importante chiamare `preventDefault()` sull'evento per bloccare la rimozione automatica, e gestire tu stesso la rimozione del tab in caso di conferma positiva da parte dell'utente.
 
-Per aggiungere tab dinamicamente con logica personalizzata, puoi utilizzare un pulsante `it-button` con `slot="after-tablist"`, e gestire l'aggiunta di un tab con un event listener che esegue la tua logica e invoca il metodo pubblico `addTab(tab, panel)`esposto dal componente.
+Per aggiungere tab dinamicamente con logica personalizzata, puoi utilizzare un pulsante `<it-button>` con `slot="after-tablist"`, e gestire l'aggiunta di un tab con un event listener che esegue la tua logica e invoca il metodo pubblico `addTab(tab, panel)`esposto dal componente.
 
 Esplora l'esempio completo con logica personalizzata di conferma prima della chiusura e aggiunta dinamica di tab:
 
@@ -199,7 +199,7 @@ Il componente espone i seguenti metodi e eventi accessibili via JavaScript.
 
 ### Metodi
 - `close(panelId: string)` - chiude il tab con id corrispondente al `panelId` passato, disattivando il tab e nascondendo il pannello. Se il tab è già chiuso o non esiste, non fa nulla.
-- `addTab(tab: ItTab, panel: ItTabPanel)` - aggiunge dinamicamente un nuovo tab e pannello al componente. Il parametro `tab` è un elemento `it-tab` con attributo `slot="tab"` e `panel="nome"`, mentre `panel` è un elemento `it-tab-panel` con attributo `name="nome"`. Il metodo si occupa di inserire correttamente i nuovi elementi nel DOM e di aggiornare la logica di selezione.
+- `addTab(tab: ItTab, panel: ItTabPanel)` - aggiunge dinamicamente un nuovo tab e pannello al componente. Il parametro `tab` è un elemento `<it-tab>` con attributo `slot="tab"` e `panel="nome"`, mentre `panel` è un elemento `<it-tab-panel>` con attributo `name="nome"`. Il metodo si occupa di inserire correttamente i nuovi elementi nel DOM e di aggiornare la logica di selezione.
 
 ### Eventi
 - `it-tab-close` — emesso quando un tab con pulsante di chiusura viene chiuso tramite click, doppio tap da mobile o shortcut da tastiera. L'evento è cancellabile e contiene `detail.panel` con l'id del pannello associato al tab chiuso.

--- a/packages/thumbnav/stories/it-thumbnav.mdx
+++ b/packages/thumbnav/stories/it-thumbnav.mdx
@@ -29,8 +29,8 @@ L'attributo `position` non ha effetto in questa anteprima: richiede una struttur
 ## Indicazioni generali
 Il componente Thumbnav è composto da due elementi:
 
-- `it-thumbnav`: contenitore che raggruppa le thumbnail e gestisce il layout;
-- `it-thumbnav-item`: singolo elemento, che accetta nello slot un anchor con immagine.
+- `<it-thumbnav>`: contenitore che raggruppa le thumbnail e gestisce il layout;
+- `<it-thumbnav-item>`: singolo elemento, che accetta nello slot un anchor con immagine.
 
 Inserisci nell'anchor la classe Bootstrap Italia `.ratio` per mantenere un rapporto d'aspetto consistente:
 
@@ -46,7 +46,7 @@ Inserisci nell'anchor la classe Bootstrap Italia `.ratio` per mantenere un rappo
 
 Se stai utilizzando il componente in un framework JS (React, Vue, Angular), utilizza il tag di navigazione del framework (ad esempio `<Link>` in React) al posto dell'anchor HTML, mantenendo la struttura interna con classe `.ratio` e immagine.
 
-Usa l'attributo `active` sull'elemento `it-thumbnav-item` corrispondente alla pagina o immagine attiva, per indicarlo visivamente agli utenti.
+Usa l'attributo `active` sull'elemento `<it-thumbnav-item>` corrispondente alla pagina o immagine attiva, per indicarlo visivamente agli utenti.
 
 ```html
 <it-thumbnav-item active>
@@ -70,14 +70,14 @@ Al fine di garantire un'esperienza accessibile a tutti gli utenti, assicurati di
       <span class="text">Nota sui test di accessibilità</span>
     </div>
     <p>
-      Axe e altri strumenti di analisi statica possono segnalare falsi positivi quando analizzano il componente `it-thumbnav` a causa del limitato supporto per i Web Components. La struttura accessibile effettiva è corretta, come confermato dall'Accessibility Tree e dai test manuali con screen reader.
+      Axe e altri strumenti di analisi statica possono segnalare falsi positivi quando analizzano il componente `<it-thumbnav>` a causa del limitato supporto per i Web Components. La struttura accessibile effettiva è corretta, come confermato dall'Accessibility Tree e dai test manuali con screen reader.
     </p>
   </div>
 </div>
 
 ## Versione small
 
-Aggiungi l'attributo `small` al contenitore `it-thumbnav` per ottenere thumbnail di dimensione ridotta (120px invece di 240px).
+Aggiungi l'attributo `small` al contenitore `<it-thumbnav>` per ottenere thumbnail di dimensione ridotta (120px invece di 240px).
 
 <Canvas of={Stories.VersioneSmall} />
 

--- a/packages/timeline/stories/it-timeline.mdx
+++ b/packages/timeline/stories/it-timeline.mdx
@@ -32,7 +32,7 @@ Segui queste indicazioni per garantire l'accessibilità del componente:
       <span class="text">Nota sui test di accessibilità</span>
     </div>
     <p>
-      Axe e altri strumenti di analisi statica possono segnalare falsi positivi quando analizzano il componente `it-timeline` a causa del limitato supporto per i Web Components. La struttura accessibile effettiva è corretta, come confermato dall'Accessibility Tree e dai test manuali con screen reader.
+      Axe e altri strumenti di analisi statica possono segnalare falsi positivi quando analizzano il componente `<it-timeline>` a causa del limitato supporto per i Web Components. La struttura accessibile effettiva è corretta, come confermato dall'Accessibility Tree e dai test manuali con screen reader.
     </p>
   </div>
 </div>
@@ -107,7 +107,7 @@ La sezione laterale è rappresentata dagli `slot="milestone"` e `slot="time"`, e
 - `.point-main` — elemento principale (obbligatorio, es. giorno, numero step, icona milestone)
 - `.point-bottom` — elemento inferiore (opzionale, es. mese, frazione, label)
 
-Questi elementi vanno inseriti in un elemento (negli esempi uno `span`) con classe `.point-visual`. Per rendere il contenuto accessibile,  ricordati di:
+Questi elementi vanno inseriti in un elemento (negli esempi uno `<span>`) con classe `.point-visual`. Per rendere il contenuto accessibile,  ricordati di:
 
 - Utilizzare sempre un elemento `<time>` con attributo `datetime` per le date
 - Aggiungere `<span class="visually-hidden">` **obbligatoriamente** per contenuti non temporali, __opzionalmente__ per date, al fine di fornire una descrizione testuale completa ai lettori di schermo.
@@ -147,7 +147,7 @@ Puoi utilizzare i contenitori posizionali per presentare informazioni diverse da
 
 #### Traguardi con icone
 
-Puoi utilizzare  un'icona `it-icon` nel contenitore `.point-main` per rappresentare milestone o stati, accompagnata da eventuali micro-testi nei contenitori `.point-top` e `.point-bottom`.
+Puoi utilizzare  un'icona `<it-icon>` nel contenitore `.point-main` per rappresentare milestone o stati, accompagnata da eventuali micro-testi nei contenitori `.point-top` e `.point-bottom`.
 
 <Canvas of={Stories.PointListMilestoneIcone} />
 
@@ -161,7 +161,7 @@ Se non viene specificato, il colore di default è `primary`.
 
 Puoi anche avere punti con colori diversi all'interno della stessa timeline specificando l'attributo `color` solo sui punti desiderati.
 
-In questo caso, gli elementi `it-timeline-point` senza l'attributo `color` prenderanno il colore di default `primary` o il valore assegnato all'attributo `color` dell'elemento `it-timeline`, mentre i punti con l'attributo `color` prenderanno il colore specificato
+In questo caso, gli elementi `<it-timeline-point>` senza l'attributo `color` prenderanno il colore di default `primary` o il valore assegnato all'attributo `color` dell'elemento `<it-timeline>`, mentre i punti con l'attributo `color` prenderanno il colore specificato
 
 <Canvas of={Stories.PointListVariantiColore} />
 

--- a/packages/toggle/stories/it-toggle.mdx
+++ b/packages/toggle/stories/it-toggle.mdx
@@ -8,7 +8,7 @@ import * as Stories from './it-toggle.stories';
 <description>Pulsante di tipo 'interruttore' che permette di alternare tra due stati e semplificare la gestione di opzioni o impostazioni.</description>
 
 ## Cosa fa
-Il componente Toggle (`it-toggle`) permette all'utente di attivare o disattivare una singola opzione attraverso un'interfaccia di tipo interruttore a levetta, visivamente più intuitiva di una semplice checkbox per questo tipo di interazione.
+Il componente Toggle (`<it-toggle>`) permette all'utente di attivare o disattivare una singola opzione attraverso un'interfaccia di tipo interruttore a levetta, visivamente più intuitiva di una semplice checkbox per questo tipo di interazione.
 
 È un'opzione utile per permettere di modificare velocemente le impostazioni di un account o le preferenze di un servizio, soprattutto quando lo spazio a disposizione è poco, come sui dispositivi mobile.
 
@@ -63,7 +63,7 @@ Questi attributi sono:
 
 Inserisci l'etichetta del gruppo in un elemento con attributo `slot="legend"` all'interno di `<it-toggle-group>`.
 
-Quando utilizzi il componente `it-toggle-group` in un form, il modo corretto per estrarre il valore del campo al submit via JS è:
+Quando utilizzi il componente `<it-toggle-group>` in un form, il modo corretto per estrarre il valore del campo al submit via JS è:
 
 ```js
 const formData = new FormData(document.getElementById('form'));

--- a/packages/toolbar/stories/it-toolbar.mdx
+++ b/packages/toolbar/stories/it-toolbar.mdx
@@ -8,7 +8,7 @@ import * as Stories from './it-toolbar.stories';
 <description>Menu di navigazione a icone che può contenere link, pulsanti e dropdown</description>
 
 ## Cosa fa
-Il componente `it-toolbar` è un elemento contenitore di link, pulsanti o dropdown.
+Il componente `<it-toolbar>` è un elemento contenitore di link, pulsanti o dropdown.
 È particolarmente utile per realizzare applicazioni molto specifiche, come ad esempio dashboard o strumenti di monitoraggio.
 Consiste in un elenco `<ul>` con tanti elementi `<li>` quante sono le voci richieste.
 Occupa tutta la larghezza del suo contenitore, adattandosi di conseguenza, e può essere di tre dimensioni diverse: grande, media e piccola per meglio adattarsi allo spazio disponibile.
@@ -23,15 +23,15 @@ Modifica gli attributi nella tabella per personalizzare in tempo reale l'aspetto
 
 <Controls of={Stories.EsempioInterattivo} />
 
-### Anteprima e attributi del componente `it-toolbar-item`
-Ogni elemento della toolbar, deve essere un componente `it-toolbar-item` che rappresenta un link, un pulsante o un dropdown. Puoi personalizzare ogni elemento modificando i suoi attributi.
+### Anteprima e attributi del componente `<it-toolbar-item>`
+Ogni elemento della toolbar, deve essere un componente `<it-toolbar-item>` che rappresenta un link, un pulsante o un dropdown. Puoi personalizzare ogni elemento modificando i suoi attributi.
 <Canvas of={Stories.ToolbarItemBase} />
 <Controls of={Stories.ToolbarItemBase} />
 
-### Eventi click di `it-toolbar-item`
-Se `it-toolbar-item` viene renderizzato come pulsante, il componente genera internamente un `it-button` nello shadow DOM. Gli attributi inline del tipo `onclick` non vengono forwardati automaticamente a quell'elemento interno.
+### Eventi click di `<it-toolbar-item>`
+Se `<it-toolbar-item>` viene renderizzato come pulsante, il componente genera internamente un `<it-button>` nello shadow DOM. Gli attributi inline del tipo `onclick` non vengono forwardati automaticamente a quell'elemento interno.
 
-Per intercettare l'azione di click, aggancia il listener direttamente a `it-toolbar-item` oppure ascolta l'evento custom `it-toolbar-item-click`, emesso dal componente in bubbling.
+Per intercettare l'azione di click, aggancia il listener direttamente a `<it-toolbar-item>` oppure ascolta l'evento custom `it-toolbar-item-click`, emesso dal componente in bubbling.
 
 ```html
 <it-toolbar-item label="Messaggi" icon="it-comment"></it-toolbar-item>
@@ -50,7 +50,7 @@ Per intercettare l'azione di click, aggancia il listener direttamente a `it-tool
 ```
 
 ## Accessibilità
-I componenti `it-toolbar` e `it-toolbar-item` sono progettati per essere accessibili e conformi agli standard di accessibilità.
+I componenti `<it-toolbar>` e `<it-toolbar-item>` sono progettati per essere accessibili e conformi agli standard di accessibilità.
 
 Ecco alcune linee guida per garantire che il tuo utilizzo del componente sia accessibile:
 - **Etichette chiare**: Assicurati che ogni elemento all'interno della toolbar (che non sia un elemento divisorio) abbia un'etichetta chiara e descrittiva.
@@ -59,7 +59,7 @@ Ecco alcune linee guida per garantire che il tuo utilizzo del componente sia acc
 
   Se le etichette sono nascoste tramite l'attributo `hide-label` assicurati di fornire una descrizione accessibile tramite gli attributi `label`, `it-aria-label` ed eventualmente `label-extended`.
 
-- Se un elemento della toolbar mostra un badge, imposta sempre l'attributo `label-extended` sul componente `it-toolbar-item` per fornire una descrizione più dettagliata del badge ai lettori di schermo.
+- Se un elemento della toolbar mostra un badge, imposta sempre l'attributo `label-extended` sul componente `<it-toolbar-item>` per fornire una descrizione più dettagliata del badge ai lettori di schermo.
 
 ## Varianti di dimensione
 
@@ -111,7 +111,7 @@ Il componente `<it-toolbar-item>` si occuperà di gestire autonomamente gli attr
 
 I Badge possono essere utilizzati per contenere numeri al fine di indicare, ad esempio, contenuti non letti.
 
-Utilizza l'attributo `badge` sul componente `it-toolbar-item` per specificare il numero da visualizzare all'interno del badge.
+Utilizza l'attributo `badge` sul componente `<it-toolbar-item>` per specificare il numero da visualizzare all'interno del badge.
 
 Utilizza l'attributo `label-extended` per fornire una descrizione più dettagliata del badge ai lettori di schermo.
 
@@ -136,8 +136,8 @@ Aggiungi l'attributo `dropdown` al componente `<it-toolbar-item>` per trasformar
 </it-toolbar-item>
 ```
 
-Se aggiungi la classe `no-expand` al componente `<it-toolbar-item>`, l'icona di espansione del menu non verrà mostrata. Questo è utile quando hai un menu del tipo `altro` o `more` il cui simbolo di espansione è già implicito nell'icona stessa e quindi l'icona di espansione risulterebbe ridondante.
-(Negli esempi sottostanti, nell'elemento 'Altro' è stata rimossa l'icona di espansione del menu tramite la classe `no-expand`).
+Se aggiungi la classe `.no-expand` al componente `<it-toolbar-item>`, l'icona di espansione del menu non verrà mostrata. Questo è utile quando hai un menu del tipo `altro` o `more` il cui simbolo di espansione è già implicito nell'icona stessa e quindi l'icona di espansione risulterebbe ridondante.
+(Negli esempi sottostanti, nell'elemento 'Altro' è stata rimossa l'icona di espansione del menu tramite la classe `.no-expand`).
 
 ### Toolbar grande con dropdown
 <Canvas of={Stories.ToolbarDropdown} />
@@ -172,12 +172,12 @@ Il componente `<it-toolbar-item>` emette i seguenti eventi custom:
 
 Per la personalizzazione degli stili puoi usare i selettori `::part` dedicati.
 
-### Selettori di `it-toolbar`
+### Selettori di `<it-toolbar>`
 
 - `::part(toolbar-container)` — elemento `<nav>` contenitore della toolbar
 - `::part(toolbar-list)` — elemento `<ul>` della lista degli item
 
-### Selettori di `it-toolbar-item`
+### Selettori di `<it-toolbar-item>`
 
 - `::part(toolbar-item)` — elemento `<li>` wrapper di ogni voce
 - `::part(toolbar-divider)` — aggiunto insieme a `toolbar-item` quando l'elemento è un divisore

--- a/packages/tooltip/stories/it-tooltip.mdx
+++ b/packages/tooltip/stories/it-tooltip.mdx
@@ -9,7 +9,7 @@ import * as TooltipStories from './it-tooltip.stories';
 
 ## Cosa fa
 
-Il componente Tooltip (`it-tooltip`) visualizza una breve etichetta testuale in overlay, posizionata dinamicamente rispetto a un elemento trigger.
+Il componente Tooltip (`<it-tooltip>`) visualizza una breve etichetta testuale in overlay, posizionata dinamicamente rispetto a un elemento trigger.
 Utilizza [Floating UI](https://floating-ui.com/) per il posizionamento intelligente e si adatta automaticamente allo spazio disponibile.
 
 A differenza del Popover, il Tooltip è pensato per contenuti brevissimi (una frase o poche parole) e si attiva automaticamente al passaggio del mouse o al focus da tastiera, senza richiedere un click.
@@ -32,7 +32,7 @@ Per vedere come cambia il codice, clicca su **Show code**.
 ## Indicazioni generali
 
 Il tooltip si attiva automaticamente al passaggio del mouse (`mouseenter`) o al focus da tastiera (`focusin`) su qualsiasi elemento interattivo inserito nello slot `trigger`.
-È adatto sia per `it-button` che per elementi nativi come `<button>` o `<a>`.
+È adatto sia per `<it-button>` che per elementi nativi come `<button>` o `<a>`.
 
 <Canvas of={TooltipStories.SuLink} />
 

--- a/packages/transfer/stories/it-transfer.mdx
+++ b/packages/transfer/stories/it-transfer.mdx
@@ -36,8 +36,8 @@ Il componente è composto da tre parti principali:
 
 Il componente Transfer è composto da due elementi:
 
-- `it-transfer`: il contenitore principale che gestisce la logica e l'integrazione con il form;
-- `it-transfer-item`: il singolo elemento trasferibile, da inserire come figlio diretto di `it-transfer`.
+- `<it-transfer>`: il contenitore principale che gestisce la logica e l'integrazione con il form;
+- `<it-transfer-item>`: il singolo elemento trasferibile, da inserire come figlio diretto di `<it-transfer>`.
 
 ```html
 <it-transfer name="my-field">
@@ -48,12 +48,12 @@ Il componente Transfer è composto da due elementi:
 
 ### Singolo elemento trasferibile
 
-`it-transfer-item` rappresenta il singolo elemento che può essere spostato tra le due liste, ed espone i seguenti attributi:
+`<it-transfer-item>` rappresenta il singolo elemento che può essere spostato tra le due liste, ed espone i seguenti attributi:
 - `value`: il valore univoco dell'elemento, che viene inviato nel form se l'elemento è presente nella lista destinazione;
 - `disabled`: se impostato, l'elemento non può essere trasferito;
 - `target`: se impostato, l'elemento parte già nella lista destinazione al caricamento.
 
-Il testo all'interno di `it-transfer-item` rappresenta l'etichetta visualizzata per l'elemento: questa può essere inserita nello slot di default, come testo semplice.
+Il testo all'interno di `<it-transfer-item>` rappresenta l'etichetta visualizzata per l'elemento: questa può essere inserita nello slot di default, come testo semplice.
 
 ## Accessibilità
 
@@ -67,7 +67,7 @@ Il componente Transfer implementa le seguenti specifiche per garantire un'esperi
 
 ## Con valori preimpostati
 
-Puoi impostare elementi nella lista destinazione al caricamento aggiungendo l'attributo `target` agli `it-transfer-item` desiderati.
+Puoi impostare elementi nella lista destinazione al caricamento aggiungendo l'attributo `target` agli `<it-transfer-item>` desiderati.
 
 <Canvas of={TransferStories.ConValoriPreimpostati} />
 
@@ -81,19 +81,19 @@ Il testo di queste etichette è importante per l'accessibilità, in quanto viene
 
 ## Elemento singolo non trasferibile
 
-Puoi rendere un singolo elemento non trasferibile con l'attributo `disabled` sull'`it-transfer-item`.
+Puoi rendere un singolo elemento non trasferibile con l'attributo `disabled` sull'`<it-transfer-item>`.
 
 <Canvas of={TransferStories.ElementoDisabilitato} />
 
 ## Stato disabilitato
 
-Impostando l'attributo `disabled` su `it-transfer`, l'intero componente viene disabilitato: le checkbox e i pulsanti non sono interagibili.
+Impostando l'attributo `disabled` su `<it-transfer>`, l'intero componente viene disabilitato: le checkbox e i pulsanti non sono interagibili.
 
 <Canvas of={TransferStories.Disabilitato} />
 
 ## Integrazione con il form
 
-Il componente `it-transfer` si integra nativamente con i form HTML. Il valore inviato alla sottomissione è un array JSON dei valori (`value`) degli elementi presenti nella lista destinazione.
+Il componente `<it-transfer>` si integra nativamente con i form HTML. Il valore inviato alla sottomissione è un array JSON dei valori (`value`) degli elementi presenti nella lista destinazione.
 
 **Esempio di valore nel form:**
 ```
@@ -171,19 +171,19 @@ el.addEventListener('it-transfer', async (e) => {
 
 ## Personalizzazione degli stili
 
-Per personalizzare l'aspetto del componente `it-transfer` dall'esterno dello shadow DOM puoi utilizzare il selettore `::part()` sui seguenti part esposti dal componente:
+Per personalizzare l'aspetto del componente `<it-transfer>` dall'esterno dello shadow DOM puoi utilizzare il selettore `::part()` sui seguenti part esposti dal componente:
 
-- `base` — il `div` radice che avvolge l'intero componente.
+- `base` — il `<div>` radice che avvolge l'intero componente.
 - `row` — la riga Bootstrap che affianca le due liste e la colonna dei pulsanti.
 - `source-col` — la colonna che contiene la lista sorgente (sinistra).
 - `buttons-col` — la colonna centrale che contiene i pulsanti di azione.
 - `target-col` — la colonna che contiene la lista destinazione (destra).
-- `source-wrapper` — il `div` della lista sorgente con bordo e intestazione (è anche il nodo `role="group"`).
-- `target-wrapper` — il `div` della lista destinazione con bordo e intestazione (è anche il nodo `role="group"`).
+- `source-wrapper` — il `<div>` della lista sorgente con bordo e intestazione (è anche il nodo `role="group"`).
+- `target-wrapper` — il `<div>` della lista destinazione con bordo e intestazione (è anche il nodo `role="group"`).
 - `header` — l'intestazione di ciascuna lista, contenente la checkbox "seleziona tutto" e il contatore degli elementi. Presente in entrambe le liste.
 - `scroll` — l'area a scorrimento verticale contenente le checkbox degli elementi. Presente in entrambe le liste.
-- `group` — il `div` interno che raggruppa le singole checkbox degli elementi. Presente in entrambe le liste.
-- `buttons` — il `div` che raggruppa i tre pulsanti di azione (trasferisci, ritrasferisci, ripristina).
+- `group` — il `<div>` interno che raggruppa le singole checkbox degli elementi. Presente in entrambe le liste.
+- `buttons` — il `<div>` che raggruppa i tre pulsanti di azione (trasferisci, ritrasferisci, ripristina).
 - `forward-button` — il pulsante che sposta gli elementi selezionati dalla lista sorgente alla lista destinazione.
 - `back-button` — il pulsante che riporta gli elementi selezionati dalla lista destinazione alla lista sorgente.
 - `reset-button` — il pulsante che ripristina entrambe le liste allo stato iniziale.

--- a/packages/upload/stories/it-upload.mdx
+++ b/packages/upload/stories/it-upload.mdx
@@ -33,7 +33,7 @@ Gli attributi condivisi dai tre componenti sono:
 
 Per `<it-upload>`, fornisci sempre un'etichetta nello slot `label` (`<span slot="label">Carica documenti</span>`): il componente la usa come testo del pulsante e come nome accessibile del campo.
 
-Se vuoi modificare l'icona del pulsante di `<it-upload>`, usa un componente `it-icon` nello slot `icon` per sostituire l'icona predefinita con una a tua scelta.
+Se vuoi modificare l'icona del pulsante di `<it-upload>`, usa un componente `<it-icon>` nello slot `icon` per sostituire l'icona predefinita con una a tua scelta.
 
 ## Accessibilità
 

--- a/packages/video/stories/it-video.mdx
+++ b/packages/video/stories/it-video.mdx
@@ -9,7 +9,7 @@ import * as Stories from './it-video.stories';
 <description>Lettore per mostrare video sul proprio sito o incorporarli da piattaforme terze rispettando privacy e accessibilità.</description>
 
 ## Cosa fa
-Il componente `it-video` consente di incorporare video all’interno delle pagine web, offrendo un lettore video accessibile e rispettoso della privacy degli utenti.
+Il componente `<it-video>` consente di incorporare video all’interno delle pagine web, offrendo un lettore video accessibile e rispettoso della privacy degli utenti.
 Supporta sia la riproduzione di video ospitati localmente che l’incorporamento di video da piattaforme esterne come YouTube, garantendo un’esperienza utente coerente e personalizzabile.
 
 Questo componente utilizza la libreria [Video.js](https://videojs.com/) per implementare funzionalità avanzate come il supporto a diversi formati video, la personalizzazione dell’interfaccia utente e l’integrazione con API esterne.


### PR DESCRIPTION
Closes #476.

Passata di uniformità sulla documentazione Storybook (58 file `.mdx`). Nessuna modifica ai contenuti, solo al modo in cui si citano gli elementi di codice.

**Tag HTML e componenti — sempre con le parentesi angolari**
- `` `it-header` `` → `` `<it-header>` ``
- `` `div` `` → `` `<div>` ``

**Classi CSS — sempre con il punto iniziale**
- `` `it-header-sticky` `` → `` `.it-header-sticky` ``
- `` `theme-light` `` → `` `.theme-light` ``

**Valori con unità di misura — unità sempre esplicita**
- Nessuna occorrenza da correggere: tutti i numeri citati nella prosa sono valori di attributi, ordinali o rapporti.

**Code span malformati — corretti**
- `` `1`,` 2` `` → `` `1`, `2` ``
- `'z-index` `` → `` `z-index` `` (in `organizzare-gli-spazi/introduzione.mdx`)

Restano volutamente senza punto né parentesi i nomi di attributi, i valori degli attributi, i nomi degli slot, i nomi delle `::part`, le proprietà CSS, gli eventi custom (es. `it-modal-open`), i prefissi delle classi di utilità (`d-`, `order-`) e i nomi di pacchetti e file. Blocchi di codice, import, URL e id delle story non sono stati toccati; `prettier --check` passa.