### PR TITLE
fix: focus ring on dropdown items ad in bsi PR1914

### DIFF
--- a/.changeset/eager-bees-try.md
+++ b/.changeset/eager-bees-try.md
@@ -1,0 +1,5 @@
+---
+'@italia/header': patch
+---
+
+Fix focus ring on dropdown item as in bsi PR1914

--- a/packages/header/styles/globals.scss
+++ b/packages/header/styles/globals.scss
@@ -336,6 +336,12 @@ it-modal#it-nav-modal {
           box-sizing: border-box;
           border-color: var(--#{$prefix}navbar-link-border-color);
           border-left: var(--#{$prefix}navbar-link-border-size) solid transparent;
+
+          &:focus-visible {
+            box-shadow:
+              inset 0 0 0 3px var(--#{$prefix}color-outline-focus),
+              inset 0 0 0 5px var(--#{$prefix}color-border-inverse) !important;
+          }
         }
       }
     }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #515 

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [ x] My branch is up-to-date with the Upstream `main` branch.
- [ x] The unit tests pass locally with my changes (if applicable).
- [ x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:
Allineato il focus mobile a bootstrap-italia#1914 — ring inset + link full-width in megamenu
 #515