### PR TITLE
fix: navscroll scrollspy offset

### DIFF
--- a/.changeset/navscroll-scrollspy-offset.md
+++ b/.changeset/navscroll-scrollspy-offset.md
@@ -1,0 +1,9 @@
+---
+'@italia/navscroll': patch
+---
+
+Fixed the scrollspy marking the wrong menu entry as active, and the animated scroll overshooting on the first and last section.
+
+The active section was measured with `offsetTop`, which is relative to the nearest positioned ancestor rather than to the scroll container. Any positioned wrapper in between falsified it — including the one `it-section` produces by default, since bootstrap-italia styles `.section-content` as `position: relative`, zeroing the `offsetTop` of every section and leaving the last menu entry permanently active. Section positions are now measured against the scroll container, the same way `scrollToElement()` already did.
+
+The scroll events emitted during the animated scroll after a click no longer overwrite the entry the click had just selected, and the animation target is clamped to the scrollable range.

--- a/.changeset/navscroll-scrollspy-offset.md
+++ b/.changeset/navscroll-scrollspy-offset.md
@@ -6,4 +6,6 @@ Fixed the scrollspy marking the wrong menu entry as active, and the animated scr
 
 The active section was measured with `offsetTop`, which is relative to the nearest positioned ancestor rather than to the scroll container. Any positioned wrapper in between falsified it — including the one `it-section` produces by default, since bootstrap-italia styles `.section-content` as `position: relative`, zeroing the `offsetTop` of every section and leaving the last menu entry permanently active. Section positions are now measured against the scroll container, the same way `scrollToElement()` already did.
 
-The scroll events emitted during the animated scroll after a click no longer overwrite the entry the click had just selected, and the animation target is clamped to the scrollable range.
+The animated scroll after a click now sets each frame's position with `behavior: 'instant'`. bootstrap-italia sets `scroll-behavior: smooth` on `:root`, so every frame of the animation used to start its own native smooth scroll: the browser chased a moving target, never reached it, and kept easing long after the animation had finished — the click landed hundreds of pixels short and the page drifted for seconds.
+
+The scroll events emitted during that animation no longer overwrite the entry the click had just selected, and the animation target is clamped to the scrollable range.

--- a/packages/navscroll/src/it-navscroll.ts
+++ b/packages/navscroll/src/it-navscroll.ts
@@ -78,6 +78,8 @@ export class ItNavscroll extends BaseComponent {
 
   private activeTarget: string | null = null; // voce di menu attiva in questo momento
 
+  private isAutoScrolling = false; // true mentre è in corso lo scroll animato dopo un click
+
   createRenderRoot() {
     // nav deve restare nel light DOM
     return this;
@@ -252,6 +254,27 @@ export class ItNavscroll extends BaseComponent {
     return this.scrollContainer === document.documentElement ? window.scrollY : this.scrollContainer.scrollTop;
   }
 
+  /**
+   * Posizione di una sezione nello spazio di scroll del container.
+   *
+   * Non si può usare `offsetTop`: è relativo all'`offsetParent`, quindi qualunque
+   * antenato posizionato fra la sezione e il container falsa la misura. Capita di
+   * default con <it-section>, che sposta il contenuto dentro `.section-content`
+   * (`position: relative`) e azzera così l'offsetTop di tutte le sezioni.
+   *
+   * `getBoundingClientRect()` è sempre relativo al viewport: sommando lo scroll
+   * corrente si ottiene la stessa scala usata da `scrollToElement()`.
+   */
+  private getSectionTop(section: HTMLElement) {
+    const rect = section.getBoundingClientRect();
+
+    if (this.scrollContainer === document.documentElement) {
+      return rect.top + window.scrollY;
+    }
+
+    return rect.top - this.scrollContainer.getBoundingClientRect().top + this.scrollContainer.scrollTop;
+  }
+
   private initContainers() {
     // Cerco il main referenziato
     const targetContainer = this.for ? document.querySelector(this.for)! : (document.scrollingElement as HTMLElement);
@@ -337,6 +360,10 @@ export class ItNavscroll extends BaseComponent {
   }
 
   private scrollHandler() {
+    // Durante lo scroll animato la voce attiva è già stata decisa dal click:
+    // le posizioni intermedie la sovrascriverebbero con la sezione sbagliata.
+    if (this.isAutoScrolling) return;
+
     const links = Array.from(this.navEl.querySelectorAll('a[href^="#"]'));
     const sections = links
       .map((link) => document.getElementById(link.getAttribute('href')!.slice(1)))
@@ -344,20 +371,15 @@ export class ItNavscroll extends BaseComponent {
 
     if (!sections.length) return;
 
-    const scrollTop = this.scrollContainer?.scrollTop;
+    const scrollTop = this.scrollContainerTop;
     const viewportHeight = this.scrollContainer.clientHeight;
 
     let currentSection: HTMLElement | null = null;
 
     for (const section of sections) {
-      const sectionTop = section.offsetTop;
+      const sectionTop = this.getSectionTop(section);
 
       // se la sezione supera il 25% del viewport del container
-      // console.log(
-      //   { scrollTop, viewportHeight, sectionTop },
-      //   'scrollTop + viewportHeight * 0.25 >= sectionTop=',
-      //   scrollTop + viewportHeight * 0.25 >= sectionTop,
-      // );
       if (scrollTop + viewportHeight * 0.25 >= sectionTop) {
         currentSection = section;
       } else {
@@ -451,8 +473,17 @@ export class ItNavscroll extends BaseComponent {
         })()
       : targetEl.getBoundingClientRect().top + targetOffset;
 
-    const distance = targetY - startY;
+    // Senza clamp l'animazione punta a una posizione irraggiungibile per la prima e
+    // l'ultima sezione: il browser la satura e il punto d'arrivo non è quello atteso.
+    const maxScroll = isScrollableContainer
+      ? container!.scrollHeight - container!.clientHeight
+      : document.documentElement.scrollHeight - window.innerHeight;
+    const clampedTargetY = Math.min(Math.max(targetY, 0), Math.max(maxScroll, 0));
+
+    const distance = clampedTargetY - startY;
     const startTime = performance.now();
+
+    this.isAutoScrolling = true;
 
     const easeInOutSine = (t: number) => -(Math.cos(Math.PI * t) - 1) / 2;
 
@@ -470,6 +501,11 @@ export class ItNavscroll extends BaseComponent {
       if (progress < 1) {
         requestAnimationFrame(step);
       } else {
+        // Lo scroll finale emette ancora un evento: si riabilita lo scrollspy
+        // solo dopo che è stato processato, altrimenti riscrive la voce attiva.
+        requestAnimationFrame(() => {
+          this.isAutoScrolling = false;
+        });
         callback?.();
       }
     };

--- a/packages/navscroll/src/it-navscroll.ts
+++ b/packages/navscroll/src/it-navscroll.ts
@@ -492,10 +492,14 @@ export class ItNavscroll extends BaseComponent {
       const progress = Math.min(elapsed / duration, 1);
       const value = startY + distance * easeInOutSine(progress);
 
+      // `behavior: 'instant'` è obbligatorio: bootstrap-italia imposta
+      // `scroll-behavior: smooth` su :root, quindi ogni assegnazione di posizione
+      // farebbe partire una propria animazione nativa. Ne partirebbe una per frame
+      // e il browser inseguirebbe un bersaglio mobile, senza mai arrivarci.
       if (isScrollableContainer) {
-        container!.scrollTop = value;
+        container!.scrollTo({ top: value, behavior: 'instant' });
       } else {
-        window.scrollTo(0, value);
+        window.scrollTo({ top: value, behavior: 'instant' });
       }
 
       if (progress < 1) {

--- a/packages/navscroll/test/it-navscroll.test.ts
+++ b/packages/navscroll/test/it-navscroll.test.ts
@@ -151,3 +151,80 @@ describe('ItNavscroll', () => {
     expect(modal.contains(el.querySelector('.link-list-wrapper'))).to.be.false;
   });
 });
+
+describe('ItNavscroll — scrollspy con antenati posizionati', () => {
+  let el: ItNavscroll;
+  let scrollContainer: HTMLElement;
+
+  // Riproduce la struttura generata da <it-section>: il contenuto finisce dentro
+  // `.section-content`, che bootstrap-italia rende `position: relative`. Diventa
+  // così l'offsetParent di ogni heading e ne azzera l'offsetTop.
+  const section = (id: string) => `
+    <div style="height:200px">
+      <div style="position:relative">
+        <h2 id="${id}">${id}</h2>
+      </div>
+    </div>
+  `;
+
+  beforeEach(async () => {
+    scrollContainer = document.createElement('div');
+    scrollContainer.id = 'positioned-scroll-container';
+    scrollContainer.style.height = '200px';
+    scrollContainer.style.overflowY = 'scroll';
+    scrollContainer.innerHTML = ['s1', 's2', 's3', 's4', 's5'].map(section).join('');
+    document.body.appendChild(scrollContainer);
+
+    el = await fixture<ItNavscroll>(html`
+      <it-navscroll breakpoint="1024" for="#positioned-scroll-container">
+        <div class="link-list-wrapper">
+          <nav>
+            <ul class="link-list">
+              <li class="nav-item">
+                <a class="nav-link" href="#s1"><span>1</span></a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="#s2"><span>2</span></a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="#s3"><span>3</span></a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="#s4"><span>4</span></a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="#s5"><span>5</span></a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </it-navscroll>
+    `);
+  });
+
+  afterEach(() => {
+    scrollContainer.remove();
+  });
+
+  const activeHrefs = () =>
+    Array.from(el.querySelectorAll<HTMLAnchorElement>('a.active')).map((a) => a.getAttribute('href'));
+
+  it('marca la sezione realmente raggiunta, non l’ultima della lista', () => {
+    // soglia: scrollTop + clientHeight * 0.25 = 300 + 50 = 350
+    // le sezioni stanno a 0, 200, 400, 600, 800 → l’attiva è la seconda
+    scrollContainer.scrollTop = 300;
+    scrollContainer.dispatchEvent(new Event('scroll'));
+
+    expect(activeHrefs()).to.deep.equal(['#s2']);
+  });
+
+  it('avanza di sezione man mano che si scorre', () => {
+    scrollContainer.scrollTop = 0;
+    scrollContainer.dispatchEvent(new Event('scroll'));
+    expect(activeHrefs()).to.deep.equal(['#s1']);
+
+    scrollContainer.scrollTop = 700;
+    scrollContainer.dispatchEvent(new Event('scroll'));
+    expect(activeHrefs()).to.deep.equal(['#s4']);
+  });
+});


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes: navscroll scrollspy offset was breaking and flickering when used with it-section components in the main body, fixed.

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

<!-- Please add a short description of what this PR resolves to be clear for the community. -->

#### Changes proposed in this Pull Request:

## <!-- You can use a few bullet points to describe some implementation changes proposed. For Example - feat: adding navbar component -->
