### PR TITLE
docs(fix): typo 

### DIFF
--- a/packages/dev-kit-italia/stories/Accessibilita.mdx
+++ b/packages/dev-kit-italia/stories/Accessibilita.mdx
@@ -96,7 +96,7 @@ Esempio di configurazione `.pa11yci`:
 ```json
 {
   "defaults": {
-    "runner": "axe",
+    "runners": "axe",
     "standard": "WCAG2AA",
     "ignore": []
   },


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [ ] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

<!-- Please add a short description of what this PR resolves to be clear for the community. -->

C'è un typo nella documentazione del file json per pa11y nella pagina Accessibilità. Manca una "s". 

#### Changes proposed in this Pull Request:

Aggiunta s ;-) cc @astagi 
